### PR TITLE
Fix SQLite threading config in DB session

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -3,5 +3,15 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.core.config import settings
 
-engine = create_engine(str(settings.DATABASE_URL), pool_pre_ping=True)
+DATABASE_URL = str(settings.DATABASE_URL)
+
+# Pour SQLite, on doit désactiver check_same_thread afin de permettre
+# l'utilisation de la même connexion dans différents threads.
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+    connect_args=connect_args,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Summary
- handle SQLite `check_same_thread` to allow multithreaded access
- tidy DB session configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a540d1d08327a21d97bbc32b7858