### PR TITLE
Persist generated exercises for chapters

### DIFF
--- a/app/services/language_chapter_generator.py
+++ b/app/services/language_chapter_generator.py
@@ -234,3 +234,5 @@ def _save_exercises_data(db: Session, chapter: chapter_model.Chapter, exercises_
             bloom_level=data.get("bloom_level", "remember"),
             content_json=data.get("content_json", {})
         )
+        db.add(component)
+    db.commit()


### PR DESCRIPTION
## Summary
- add KnowledgeComponent entries to DB and commit after saving exercises

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a03ad457a08327b25b5ccf6f78de50