### PR TITLE
Include vocab and grammar references in dialogue prompt

### DIFF
--- a/app/core/ai_service.py
+++ b/app/core/ai_service.py
@@ -333,6 +333,8 @@ def generate_language_dialogue(
         max_turns=kwargs.get("max_turns", 8),
         include_transliteration=kwargs.get("include_transliteration"),
         include_french_gloss=kwargs.get("include_french_gloss"),
+        vocab_refs=vocab_refs,
+        grammar_refs=grammar_refs,
         ensure_json=True
     )
 

--- a/app/prompts/language_generation/dialogue.md
+++ b/app/prompts/language_generation/dialogue.md
@@ -2,6 +2,10 @@
 Tu es scénariste pédagogique pour "{{ course_title }}", chapitre "{{ chapter_title }}".
 Écris un dialogue court, naturel, qui UTILISE principalement le vocabulaire et ILLUSTRE les règles de grammaire fournies.
 
+VOCABULAIRE CIBLE: {{ vocab_refs }}
+GRAMMAIRE CIBLE: {{ grammar_refs }}
+Utilise chaque référence ci-dessus au moins une fois dans le dialogue et indique les IDs correspondants dans chaque réplique.
+
 PARAMÈTRES:
 - max_turns={{ max_turns|default(8) }}
 - include_transliteration={{ include_transliteration|default(true) }}


### PR DESCRIPTION
## Summary
- Pass `vocab_refs` and `grammar_refs` to dialogue prompt construction
- Document vocabulary and grammar placeholders with usage instructions

## Testing
- `PYENV_VERSION=3.11.12 pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a03adf53ec8327b431b89e38c59aa9