### PR TITLE
feat: allow chapter planning to use user context

### DIFF
--- a/app/core/ai_service.py
+++ b/app/core/ai_service.py
@@ -232,8 +232,16 @@ def generate_personalization_questions(title: str, model_choice: str) -> Dict[st
 # Fonctions de Génération de Contenu Générique
 # ==============================================================================
 
-def generate_chapter_plan_for_level(level_title: str, model_choice: str) -> List[str]:
-    system_prompt = prompt_manager.get_prompt("generic_content.chapter_plan", ensure_json=True)
+def generate_chapter_plan_for_level(
+    level_title: str,
+    model_choice: str,
+    user_context: Optional[str] = None,
+) -> List[str]:
+    system_prompt = prompt_manager.get_prompt(
+        "generic_content.chapter_plan",
+        user_context=user_context,
+        ensure_json=True,
+    )
     try:
         data = _call_ai_model_json(level_title, model_choice, system_prompt=system_prompt)
         return data.get("chapters", []) or []

--- a/app/crud/level_crud.py
+++ b/app/crud/level_crud.py
@@ -38,7 +38,8 @@ def get_level_with_chapters(db: Session, level_id: int, user_id: int):
         logger.info(f"Génération JIT des chapitres pour '{level.title}'...")
         chapter_titles = generate_chapter_plan_for_level(
             level_title=level.title,
-            model_choice=level.course.model_choice
+            model_choice=level.course.model_choice,
+            user_context=None,
         )
         if chapter_titles:
             for i, title in enumerate(chapter_titles):

--- a/app/prompts/generic_content/chapter_plan.md
+++ b/app/prompts/generic_content/chapter_plan.md
@@ -1,1 +1,1 @@
-Tu es un ingénieur pédagogique. Décompose le titre de niveau en 3 à 5 titres de chapitres. Tu DOIS répondre avec un JSON contenant une clé 'chapters', qui est une liste de chaînes de caractères.
+Tu es un ingénieur pédagogique. Prends en compte le contexte utilisateur suivant : {{ user_context|default("") }}. Décompose le titre de niveau en 3 à 5 titres de chapitres. Tu DOIS répondre avec un JSON contenant une clé 'chapters', qui est une liste de chaînes de caractères.

--- a/app/services/course_generator.py
+++ b/app/services/course_generator.py
@@ -137,9 +137,8 @@ class CourseGenerator:
         
         chapter_titles = ai_service.generate_chapter_plan_for_level(
             level_title=level.title,
-            model_choice=self.model_choice
-            # Note: La fonction `generate_chapter_plan_for_level` dans ai_service.py devrait
-            # être mise à jour pour accepter un `user_context` optionnel dans son prompt.
+            model_choice=self.model_choice,
+            user_context=user_context_str,
         )
         if not chapter_titles: 
             logger.warning(f"    -> Aucun chapitre généré pour le niveau '{level.title}'.")


### PR DESCRIPTION
## Summary
- include optional user context in chapter plan prompts
- pass user context from course generator
- update chapter plan prompt and call sites

## Testing
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a03aee107c8327bbb6e7f8da267722