### PR TITLE
Fix websocket authentication route

### DIFF
--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -23,7 +23,7 @@ api_router.include_router(feedback_router.router, prefix="/feedback", tags=["Fee
 api_router.include_router(nlp_router.router, prefix="/nlp", tags=["Nlp"])
 api_router.include_router(capsule_router.router, prefix="/capsules", tags=["Capsule"])
 api_router.include_router(notification_router.router, prefix="/notifications", tags=["Notifications"])
-api_router.include_router(notification_ws.router, prefix="/notifications", tags=["Notifications"])
+api_router.include_router(notification_ws.router, tags=["Notifications"])
 api_router.include_router(badge_router.router, prefix="/badges", tags=["Badges"])
 api_router.include_router(programming_router.router, prefix="/programming", tags=["Programming"])
 api_router.include_router(stripe_router.router, prefix="/stripe", tags=["stripe"])


### PR DESCRIPTION
## Summary
- register the notification websocket router without a prefix so it is available at `/api/v2/ws`
- read the authentication token directly from the websocket query string and keep a legacy `/api/v2/notifications/ws` alias

## Testing
- ⚠️ `pytest` *(fails: pyenv reports Python 3.11.9 is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3845787883279ff17b194ca34db7