### PR TITLE
Ensure Stripe subscription upgrades users to premium

### DIFF
--- a/scripts/run_seeds.py
+++ b/scripts/run_seeds.py
@@ -140,6 +140,14 @@ def seed_badges(db: Session):
             "points": 5,
         },
         {
+            "name": "Abonné Premium",
+            "slug": "premium-subscriber",
+            "description": "Un abonnement premium est actif sur ce compte.",
+            "icon": "crown",
+            "category": "Premium",
+            "points": 50,
+        },
+        {
             "name": "Artisan en herbe",
             "slug": "artisan-premiere-capsule",
             "description": "Première capsule générée",


### PR DESCRIPTION
## Summary
- centralize Stripe webhook handling so completed checkouts, invoices and subscription updates mark users as premium
- update premium downgrade path to reset presentation when subscriptions are cancelled
- seed the `premium-subscriber` badge for the premium membership reward

## Testing
- python3 -m pytest tests/test_feedback_router.py *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fb9d2910832797767eb3e0b52113