### PR TITLE
Add account deletion scheduling and Stripe cancellation endpoints

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -71,6 +71,8 @@ class UserAdmin(ModelView, model=User):
         User.stripe_customer_id,
         User.created_at,
         User.last_login_at,
+        User.account_deletion_requested_at,
+        User.account_deletion_scheduled_at,
     ]
     column_searchable_list = [User.username, User.email, User.stripe_customer_id]
     column_sortable_list = [User.created_at, User.last_login_at]

--- a/app/models/user/user_model.py
+++ b/app/models/user/user_model.py
@@ -52,6 +52,12 @@ class User(Base):
         server_default=SubscriptionStatus.FREE.value
     )
     stripe_customer_id: Mapped[Optional[str]] = mapped_column(String(255), unique=True, index=True, nullable=True)
+    account_deletion_requested_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    account_deletion_scheduled_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     
     # --- Relations (inchangées) ---
     enrollments: Mapped[List["UserCapsuleEnrollment"]] = relationship(back_populates="user", cascade="all, delete-orphan")

--- a/app/schemas/user/user_schema.py
+++ b/app/schemas/user/user_schema.py
@@ -31,8 +31,17 @@ class User(UserBase):
     id: int
     is_active: bool
     is_superuser: bool
+    is_email_verified: bool
     created_at: datetime
+    last_login_at: Optional[datetime] = None
+    active_title: Optional[str] = None
+    profile_border_color: Optional[str] = None
+    xp_points: int
+    level: int
     subscription_status: SubscriptionStatus = SubscriptionStatus.FREE
+    stripe_customer_id: Optional[str] = None
+    account_deletion_requested_at: Optional[datetime] = None
+    account_deletion_scheduled_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True # Permet à Pydantic de lire les modèles SQLAlchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///test.db")
+os.environ.setdefault("RESEND_API_KEY", "test-resend")
+os.environ.setdefault("FRONTEND_BASE_URL", "http://localhost:5173")
+os.environ.setdefault("BACKEND_BASE_URL", "http://localhost:8000")
+os.environ.setdefault("EMAIL_FROM", "noreply@example.com")
+os.environ.setdefault("SECRET_KEY", "secret-key")
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test")
+os.environ.setdefault("STRIPE_PREMIUM_PRICE_ID", "price_test")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test")
 
 from app.db.base_class import Base
 from app.models.analytics.feedback_model import (
@@ -29,6 +40,7 @@ from app.models.progress.user_answer_log_model import UserAnswerLog
 from app.models.progress.user_atomic_progress import UserAtomProgress
 from app.models.progress.user_course_progress_model import UserCourseProgress
 from app.models.toolbox.coach_energy_model import CoachEnergyWallet
+from app.models.email.email_token import EmailToken
 
 
 # Ensure the backend/app package is importable when tests run from the repo root.
@@ -53,6 +65,7 @@ TABLES = [
     ContentFeedback.__table__,
     ContentFeedbackDetail.__table__,
     CoachEnergyWallet.__table__,
+    EmailToken.__table__,
     Notification.__table__,
     Badge.__table__,
     UserBadge.__table__,

--- a/tests/test_user_account_settings.py
+++ b/tests/test_user_account_settings.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+
+import pytest
+import stripe
+from fastapi import HTTPException
+
+from app.api.v2.endpoints import user_router, stripe_router
+from app.schemas.user.user_schema import UserUpdate
+from app.models.user.user_model import SubscriptionStatus
+from tests.utils import create_user
+
+
+@pytest.mark.asyncio
+async def test_update_me_updates_core_fields(monkeypatch, db_session):
+    user = create_user(
+        db_session,
+        username="oldname",
+        email="old@example.com",
+        full_name=None,
+        is_email_verified=True,
+    )
+
+    async def fake_send_confirm_email(db, user_obj, lang):
+        fake_send_confirm_email.called = (db, user_obj, lang)
+
+    fake_send_confirm_email.called = None
+    monkeypatch.setattr(user_router, "send_confirm_email", fake_send_confirm_email)
+
+    payload = UserUpdate(
+        email="new@example.com",
+        username="newname",
+        full_name="  New Full Name  ",
+    )
+    request = SimpleNamespace(headers={})
+
+    updated_user = await user_router.update_me(payload, request, db_session, user)
+
+    assert updated_user.email == "new@example.com"
+    assert updated_user.username == "newname"
+    assert updated_user.full_name == "New Full Name"
+    assert updated_user.is_email_verified is False
+    assert fake_send_confirm_email.called is not None
+
+
+@pytest.mark.asyncio
+async def test_update_me_prevents_duplicate_email(monkeypatch, db_session):
+    user = create_user(
+        db_session,
+        username="primary",
+        email="primary@example.com",
+        full_name="User",
+        is_email_verified=True,
+    )
+    other = create_user(
+        db_session,
+        username="other",
+        email="duplicate@example.com",
+        full_name="Other",
+        is_email_verified=True,
+    )
+
+    async def fake_send_confirm_email(*args, **kwargs):  # pragma: no cover - ne doit pas être appelé
+        raise AssertionError("send_confirm_email should not be called")
+
+    monkeypatch.setattr(user_router, "send_confirm_email", fake_send_confirm_email)
+
+    request = SimpleNamespace(headers={})
+    payload = UserUpdate(email="duplicate@example.com")
+
+    with pytest.raises(HTTPException) as exc:
+        await user_router.update_me(payload, request, db_session, user)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Email already registered"
+
+    db_session.refresh(user)
+    assert user.email == "primary@example.com"
+
+
+@pytest.mark.asyncio
+async def test_cancel_subscription_revokes_premium(monkeypatch, db_session):
+    user = create_user(
+        db_session,
+        username="premium",
+        email="premium@example.com",
+        subscription_status=SubscriptionStatus.PREMIUM,
+        stripe_customer_id="cus_123",
+        active_title="Membre Premium",
+        profile_border_color="#FFD700",
+    )
+
+    class FakeList:
+        def __init__(self):
+            self.data = [{"id": "sub_1", "status": "active"}]
+
+    def fake_list(**kwargs):
+        return FakeList()
+
+    canceled = []
+
+    def fake_delete(sub_id):
+        canceled.append(sub_id)
+        return {"id": sub_id, "status": "canceled"}
+
+    monkeypatch.setattr(stripe.Subscription, "list", fake_list)
+    monkeypatch.setattr(stripe.Subscription, "delete", fake_delete)
+
+    result = await stripe_router.cancel_subscription(current_user=user, db=db_session)
+
+    assert result == {"status": "canceled", "canceled_subscriptions": ["sub_1"]}
+
+    db_session.refresh(user)
+    assert user.subscription_status == SubscriptionStatus.CANCELED
+    assert user.active_title is None
+    assert user.profile_border_color is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_account_deletion_marks_user(monkeypatch, db_session):
+    user = create_user(
+        db_session,
+        username="deleteme",
+        email="delete@example.com",
+        subscription_status=SubscriptionStatus.PREMIUM,
+        stripe_customer_id="cus_del",
+        active_title="Membre Premium",
+        profile_border_color="#FFD700",
+    )
+
+    monkeypatch.setattr(
+        stripe_router,
+        "_cancel_active_subscriptions_for_customer",
+        lambda customer_id: ["sub_del"] if customer_id == "cus_del" else [],
+    )
+
+    result = await user_router.schedule_account_deletion(db_session, user)
+
+    assert result["status"] == "scheduled"
+    assert result["canceled_stripe_subscriptions"] == ["sub_del"]
+
+    db_session.refresh(user)
+    assert user.is_active is False
+    assert user.subscription_status == SubscriptionStatus.CANCELED
+    assert user.account_deletion_requested_at is not None
+    assert user.account_deletion_scheduled_at is not None
+    assert (user.account_deletion_scheduled_at - user.account_deletion_requested_at).days == 30


### PR DESCRIPTION
## Summary
- add fields on the user model/schema/admin for tracking scheduled account deletions
- extend the user router with richer profile updates, login guards, and a deletion scheduler while exposing a Stripe cancel endpoint
- harden authentication helpers and test fixtures, and cover the new flows with dedicated tests

## Testing
- PYENV_VERSION=3.11.12 pytest tests/test_stripe_premium_badge.py tests/test_user_account_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d11b5bee908327bc55e4c176d1fc01