### PR TITLE
Handle missing env defaults for Vercel deployment

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,15 +1,40 @@
 # Fichier: nanshe/backend/app/core/config.py (CORRIGÉ)
-from pydantic_settings import BaseSettings
-from typing import Optional, List, Union
-from pydantic import AnyHttpUrl
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import List, Optional
+
+from pydantic import AliasChoices, AnyHttpUrl, Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+def _default_secret_key() -> str:
+    """Génère une clé secrète éphémère utilisée lorsque la configuration est incomplète."""
+
+    return secrets.token_urlsafe(32)
+
 
 class Settings(BaseSettings):
-    DATABASE_URL: str
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    DATABASE_URL: str = Field(
+        default="sqlite+aiosqlite:///./nanshe.db",
+        validation_alias=AliasChoices(
+            "DATABASE_URL",
+            "POSTGRES_URL",
+            "POSTGRES_PRISMA_URL",
+            "POSTGRES_URL_NO_SSL",
+            "SUPABASE_DB_URL",
+        ),
+    )
     GOOGLE_API_KEY: Optional[str] = None
     LOCAL_LLM_URL: Optional[str] = None
     REPLICATE_API_TOKEN: Optional[str] = None
     OPENAI_API_KEY: Optional[str] = None
-    STRIPE_SECRET_KEY: Optional[str] = None 
+    STRIPE_SECRET_KEY: Optional[str] = None
     STRIPE_PUBLISHABLE_KEY: Optional[str] = None
     STRIPE_PREMIUM_PRICE_ID: Optional[str] = None
     STRIPE_WEBHOOK_SECRET: Optional[str] = None
@@ -19,17 +44,16 @@ class Settings(BaseSettings):
         "http://127.0.0.1:5173",
         "https://nanshefr-v2.vercel.app",
     ]
-    RESEND_API_KEY: str
+    RESEND_API_KEY: str = Field(default="test-resend")
 
-    FRONTEND_BASE_URL: AnyHttpUrl
-    BACKEND_BASE_URL: AnyHttpUrl
+    FRONTEND_BASE_URL: AnyHttpUrl = Field(default="http://localhost:5173")
+    BACKEND_BASE_URL: AnyHttpUrl = Field(default="http://localhost:8000")
     EMAIL_CONFIRM_TTL_H: int = 48
     EMAIL_RESET_TTL_MIN: int = 30
     RESEND_WEBHOOK_SECRET: str | None = None
 
-
     MAIL_PROVIDER: str = "resend"  # "sendgrid" | "brevo_smtp" | "resend"
-    EMAIL_FROM: str
+    EMAIL_FROM: str = Field(default="noreply@example.com")
 
     # SendGrid
     SENDGRID_API_KEY: Optional[str] = None
@@ -39,12 +63,12 @@ class Settings(BaseSettings):
     BREVO_SMTP_PORT: int = 587
     BREVO_SMTP_USER: Optional[str] = None
     BREVO_SMTP_PASSWORD: Optional[str] = None
-    
+
     ENVIRONMENT: str = "development"
-    
+
     # --- NOUVELLE LIGNE ---
     # La clé secrète pour signer les JWTs.
-    SECRET_KEY: str
+    SECRET_KEY: str = Field(default_factory=_default_secret_key)
 
     # Configuration des embeddings
     USE_REMOTE_EMBEDDINGS: bool = False
@@ -56,7 +80,34 @@ class Settings(BaseSettings):
     COACH_ENERGY_RECOVERY_MINUTES: int = 24 * 60  # full refill over 24 hours by default
     COACH_ENERGY_MESSAGE_COST: float = 1.0
 
-    class Config:
-        env_file = ".env"
+    @field_validator("DATABASE_URL", mode="after")
+    @classmethod
+    def _normalise_database_url(cls, value: str) -> str:
+        if value.startswith("postgres://"):
+            return "postgresql+asyncpg://" + value.removeprefix("postgres://")
+        if value.startswith("postgresql://") and "+asyncpg" not in value:
+            return "postgresql+asyncpg://" + value.removeprefix("postgresql://")
+        return value
+
+    @model_validator(mode="after")
+    def _warn_on_defaults(self) -> "Settings":
+        if "DATABASE_URL" not in self.model_fields_set and self.DATABASE_URL.startswith("sqlite"):
+            logger.warning(
+                "DATABASE_URL manquant : utilisation d'une base SQLite locale, non recommandée en production."
+            )
+        if "RESEND_API_KEY" not in self.model_fields_set or self.RESEND_API_KEY == "test-resend":
+            logger.warning(
+                "RESEND_API_KEY manquant : l'envoi d'e-mails transactionnels sera désactivé."
+            )
+        if "EMAIL_FROM" not in self.model_fields_set:
+            logger.warning(
+                "EMAIL_FROM non défini : utilisation de l'expéditeur par défaut %s.", self.EMAIL_FROM
+            )
+        if "SECRET_KEY" not in self.model_fields_set:
+            logger.warning(
+                "SECRET_KEY non défini : génération d'une clé éphémère, pensez à la définir pour les sessions."
+            )
+        return self
+
 
 settings = Settings()

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,27 +1,48 @@
 # Fichier: backend/app/db/session.py (VERSION FINALE)
-from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from __future__ import annotations
+
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
+
 from app.core.config import settings
+
+
+def _build_sync_url(url: str) -> tuple[str, dict[str, object]]:
+    """Convertit l'URL de connexion async en équivalent synchrone."""
+
+    connect_args: dict[str, object] = {}
+    if url.startswith("sqlite+aiosqlite"):
+        sync_url = url.replace("+aiosqlite", "", 1)
+        connect_args["check_same_thread"] = False
+        return sync_url, connect_args
+    if url.startswith("postgresql+asyncpg"):
+        return url.replace("+asyncpg", "", 1), connect_args
+    return url, connect_args
+
 
 # --- Moteur Asynchrone (pour SQLAdmin) ---
 # Lit l'URL complète "postgresql+asyncpg://..." de votre .env
+database_url = str(settings.DATABASE_URL)
 async_engine = create_async_engine(
-    str(settings.DATABASE_URL),
+    database_url,
     echo=False,
     future=True,
 )
 
+
 # --- Moteur Synchrone (pour votre API existante) ---
-# On retire "+asyncpg" pour que SQLAlchemy utilise le pilote synchrone par défaut (psycopg2)
-sync_db_url = str(settings.DATABASE_URL).replace("+asyncpg", "")
+sync_db_url, connect_args = _build_sync_url(database_url)
 sync_engine = create_engine(
     sync_db_url,
-    pool_pre_ping=True
+    pool_pre_ping=True,
+    connect_args=connect_args,
 )
+
 
 # Fabrique de sessions pour votre API (synchrone)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=sync_engine)
+
 
 # Dépendance FastAPI pour les sessions synchrones (utilisée par vos routeurs API)
 def get_db():


### PR DESCRIPTION
## Summary
- add sensible defaults and logging warnings for missing environment variables so the API can boot on Vercel
- normalise database URLs from multiple providers and generate fallback secrets/placeholders when not provided
- update the session factory to handle SQLite fallbacks alongside PostgreSQL async URLs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15629aa008327bf7e78e14bd8aaef