### PR TITLE
Add modular websocket conversations backend

### DIFF
--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -16,6 +16,7 @@ from .endpoints import (
     auth_email_router,
     resend_webhook_router,
     legal_router,
+    conversation_ws,
 )
 
 api_router = APIRouter()
@@ -28,6 +29,7 @@ api_router.include_router(nlp_router.router, prefix="/nlp", tags=["Nlp"])
 api_router.include_router(capsule_router.router, prefix="/capsules", tags=["Capsule"])
 api_router.include_router(notification_router.router, prefix="/notifications", tags=["Notifications"])
 api_router.include_router(notification_ws.router, tags=["Notifications"])
+api_router.include_router(conversation_ws.router, tags=["Conversations"])
 api_router.include_router(ws_debug.router,prefix="/ws-test", tags=["WsDebug"])
 api_router.include_router(badge_router.router, prefix="/badges", tags=["Badges"])
 api_router.include_router(programming_router.router, prefix="/programming", tags=["Programming"])

--- a/app/api/v2/endpoints/conversation_ws.py
+++ b/app/api/v2/endpoints/conversation_ws.py
@@ -1,0 +1,141 @@
+"""WebSocket endpoint powering in-memory conversations."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, Query, WebSocket, WebSocketDisconnect, status
+from jose import ExpiredSignatureError
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from app.api.v2.dependencies import _decode_user_from_token, get_db
+from app.conversations import (
+    ChannelDescriptor,
+    ConversationMessage,
+    MessageOptions,
+    UserPublicInfo,
+    conversation_ws_manager,
+)
+
+router = APIRouter()
+log = logging.getLogger("conversation_ws")
+
+
+@router.websocket("/ws/conversations")
+async def conversations_ws(
+    websocket: WebSocket,
+    domain: str | None = Query(default=None, description="Salon/domain for the conversation"),
+    area: str | None = Query(default=None, description="Optional area tag for the conversation"),
+    db: Session = Depends(get_db),
+) -> None:
+    """Authenticate the websocket, attach it to the right channel and stream messages."""
+
+    token = websocket.cookies.get("access_token") or websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    try:
+        current_user = _decode_user_from_token(token, db)
+    except ExpiredSignatureError:
+        log.warning("Conversation WS refused: token expired")
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+    except Exception:
+        log.warning("Conversation WS refused: token invalid")
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        return
+
+    channel = ChannelDescriptor.from_params(domain=domain, area=area)
+    await conversation_ws_manager.connect(channel, websocket)
+    log.info(
+        "[WS CONVERSATION CONNECTED] user=%s channel=%s scope=%s",
+        current_user.id,
+        channel.key,
+        channel.scope,
+    )
+
+    await websocket.send_json({"type": "channel.ready", "payload": channel.payload()})
+    await conversation_ws_manager.send_history(channel, websocket)
+
+    try:
+        while True:
+            try:
+                payload = await websocket.receive_json()
+            except WebSocketDisconnect:
+                raise
+            except json.JSONDecodeError:
+                await websocket.send_json({"type": "error", "error": "invalid_json"})
+                continue
+
+            action = payload.get("action")
+            if action == "send_message":
+                await _handle_send_message(payload, websocket, channel, current_user)
+            elif action == "request_history":
+                await conversation_ws_manager.send_history(channel, websocket)
+            elif action == "heartbeat":
+                await websocket.send_json(
+                    {
+                        "type": "heartbeat",
+                        "payload": {"ts": datetime.now(timezone.utc).isoformat()},
+                    }
+                )
+            else:
+                await websocket.send_json(
+                    {
+                        "type": "error",
+                        "error": "unknown_action",
+                        "action": action,
+                    }
+                )
+    except WebSocketDisconnect:
+        log.info(
+            "[WS CONVERSATION DISCONNECTED] user=%s channel=%s",
+            current_user.id,
+            channel.key,
+        )
+    finally:
+        await conversation_ws_manager.disconnect(channel, websocket)
+
+
+def _safe_text(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+async def _handle_send_message(payload: dict[str, Any], websocket: WebSocket, channel: ChannelDescriptor, user) -> None:
+    content = _safe_text(payload.get("content"))
+    if not content:
+        await websocket.send_json({"type": "error", "error": "empty_message"})
+        return
+
+    options_data = payload.get("options") or {}
+    try:
+        options = MessageOptions(**options_data)
+    except ValidationError as exc:
+        await websocket.send_json(
+            {
+                "type": "error",
+                "error": "invalid_options",
+                "details": exc.errors(),
+            }
+        )
+        return
+
+    message = ConversationMessage(
+        id=str(uuid4()),
+        scope=channel.scope,
+        domain=channel.domain,
+        area=channel.area,
+        content=content,
+        created_at=datetime.now(timezone.utc),
+        user=UserPublicInfo.model_validate(user),
+        options=options,
+    )
+    await conversation_ws_manager.broadcast_message(channel, message)

--- a/app/conversations/__init__.py
+++ b/app/conversations/__init__.py
@@ -1,0 +1,20 @@
+"""Conversation websocket infrastructure."""
+
+from .manager import conversation_ws_manager, ConversationWebSocketManager
+from .schemas import (
+    ChannelDescriptor,
+    ConversationMessage,
+    ConversationScope,
+    MessageOptions,
+    UserPublicInfo,
+)
+
+__all__ = [
+    "conversation_ws_manager",
+    "ConversationWebSocketManager",
+    "ChannelDescriptor",
+    "ConversationMessage",
+    "ConversationScope",
+    "MessageOptions",
+    "UserPublicInfo",
+]

--- a/app/conversations/manager.py
+++ b/app/conversations/manager.py
@@ -1,0 +1,132 @@
+"""In-memory manager responsible for conversation websocket state."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import deque
+from typing import Deque, List, MutableMapping, MutableSet
+
+from fastapi import WebSocket
+from fastapi.encoders import jsonable_encoder
+from starlette.websockets import WebSocketState
+
+from .schemas import ChannelDescriptor, ConversationMessage
+
+log = logging.getLogger("conversation_ws")
+
+
+class ConversationWebSocketManager:
+    """Manage websocket connections and message history for conversations."""
+
+    def __init__(self, history_size: int = 200) -> None:
+        self._history_size = history_size
+        self._connections: MutableMapping[str, MutableSet[WebSocket]] = {}
+        self._messages: MutableMapping[str, Deque[ConversationMessage]] = {}
+        self._lock = asyncio.Lock()
+
+    async def connect(self, channel: ChannelDescriptor, websocket: WebSocket) -> None:
+        """Accept and register a websocket for the given channel."""
+
+        await websocket.accept()
+        key = channel.key
+        async with self._lock:
+            self._connections.setdefault(key, set()).add(websocket)
+        log.info("[WS CONVERSATION CONNECT] channel=%s total=%s", key, await self.connection_count(channel))
+
+    async def disconnect(self, channel: ChannelDescriptor, websocket: WebSocket) -> None:
+        """Remove a websocket from the given channel."""
+
+        key = channel.key
+        async with self._lock:
+            connections = self._connections.get(key)
+            if not connections:
+                return
+            connections.discard(websocket)
+            if not connections:
+                self._connections.pop(key, None)
+        log.info("[WS CONVERSATION DISCONNECT] channel=%s remaining=%s", key, await self.connection_count(channel))
+
+    async def connection_count(self, channel: ChannelDescriptor) -> int:
+        """Return the number of active websocket connections for a channel."""
+
+        key = channel.key
+        async with self._lock:
+            return len(self._connections.get(key, set()))
+
+    async def broadcast_message(self, channel: ChannelDescriptor, message: ConversationMessage) -> None:
+        """Store the message in history and broadcast it to every subscriber."""
+
+        await self._store_message(channel, message)
+        payload = {"type": "message", "payload": message.model_dump(mode="json")}
+        await self._broadcast(channel, payload)
+
+    async def send_history(self, channel: ChannelDescriptor, websocket: WebSocket) -> None:
+        """Send the cached history to a single websocket connection."""
+
+        history = await self.history(channel)
+        payload = {
+            "type": "history",
+            "payload": [message.model_dump(mode="json") for message in history],
+        }
+        await self._send_payload(websocket, payload)
+
+    async def history(self, channel: ChannelDescriptor) -> List[ConversationMessage]:
+        """Return a copy of the cached history for a channel."""
+
+        key = channel.key
+        async with self._lock:
+            buffer = self._messages.get(key, deque(maxlen=self._history_size))
+            return list(buffer)
+
+    async def _store_message(self, channel: ChannelDescriptor, message: ConversationMessage) -> None:
+        key = channel.key
+        async with self._lock:
+            buffer = self._messages.get(key)
+            if buffer is None:
+                buffer = deque(maxlen=self._history_size)
+                self._messages[key] = buffer
+            buffer.append(message)
+
+    async def _broadcast(self, channel: ChannelDescriptor, payload: dict) -> None:
+        key = channel.key
+        websockets = await self._connections_snapshot(key)
+        if not websockets:
+            return
+        text_payload = self._encode_payload(payload)
+        stale: list[WebSocket] = []
+        for websocket in websockets:
+            try:
+                if websocket.application_state != WebSocketState.CONNECTED:
+                    stale.append(websocket)
+                    continue
+                await websocket.send_text(text_payload)
+            except Exception:  # pragma: no cover - defensive
+                log.exception("[WS CONVERSATION SEND ERROR] channel=%s", key)
+                stale.append(websocket)
+        if stale:
+            async with self._lock:
+                connections = self._connections.get(key)
+                if connections:
+                    for websocket in stale:
+                        connections.discard(websocket)
+                    if not connections:
+                        self._connections.pop(key, None)
+
+    async def _connections_snapshot(self, key: str) -> List[WebSocket]:
+        async with self._lock:
+            return list(self._connections.get(key, set()))
+
+    async def _send_payload(self, websocket: WebSocket, payload: dict) -> None:
+        text_payload = self._encode_payload(payload)
+        try:
+            await websocket.send_text(text_payload)
+        except Exception:  # pragma: no cover - defensive
+            log.exception("[WS CONVERSATION SEND ERROR] single websocket")
+
+    def _encode_payload(self, payload: dict) -> str:
+        return json.dumps(jsonable_encoder(payload), ensure_ascii=False, separators=(",", ":"))
+
+
+conversation_ws_manager = ConversationWebSocketManager()

--- a/app/conversations/schemas.py
+++ b/app/conversations/schemas.py
@@ -1,0 +1,109 @@
+"""Pydantic models used by the conversation websocket backend."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConversationScope(str, Enum):
+    """Different scopes supported by the conversation service."""
+
+    GENERAL = "general"
+    DOMAIN = "domain"
+
+
+class ChannelDescriptor(BaseModel):
+    """Represents a logical conversation channel."""
+
+    scope: ConversationScope
+    domain: str | None = Field(default=None, description="Salon or domain identifier")
+    area: str | None = Field(default=None, description="Optional area tag inside the domain")
+
+    model_config = ConfigDict(frozen=True, use_enum_values=True)
+
+    @classmethod
+    def from_params(
+        cls, *, domain: str | None = None, area: str | None = None
+    ) -> "ChannelDescriptor":
+        """Build a channel descriptor from optional request parameters."""
+
+        normalized_domain = _normalize_identifier(domain)
+        normalized_area = _normalize_identifier(area)
+
+        # "general" (or blank) is treated as the global room
+        if normalized_domain in {None, "general"}:
+            normalized_domain = None
+            scope = ConversationScope.GENERAL
+        else:
+            scope = ConversationScope.DOMAIN
+
+        return cls(scope=scope, domain=normalized_domain, area=normalized_area)
+
+    @property
+    def key(self) -> str:
+        """Stable key used to store channel specific state."""
+
+        domain_part = (self.domain or "general").lower()
+        area_part = (self.area or "*").lower()
+        return f"{self.scope}:{domain_part}:{area_part}"
+
+    def payload(self) -> Dict[str, Any]:
+        """Serializable representation used when notifying clients."""
+
+        return {
+            "scope": self.scope.value,
+            "domain": self.domain,
+            "area": self.area,
+            "key": self.key,
+        }
+
+
+def _normalize_identifier(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+class UserPublicInfo(BaseModel):
+    """Subset of user information exposed over the websocket."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    username: str
+    full_name: str | None = None
+    active_title: str | None = None
+    profile_border_color: str | None = None
+    level: int | None = None
+    xp_points: int | None = None
+
+
+class MessageOptions(BaseModel):
+    """Options that control message presentation and counters."""
+
+    citation_count: int = Field(default=0, ge=0)
+    reply_count: int = Field(default=0, ge=0)
+    allow_comments: bool = Field(default=True)
+    extra: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ConversationMessage(BaseModel):
+    """Canonical representation of a conversation message."""
+
+    model_config = ConfigDict(extra="allow", frozen=True, use_enum_values=True)
+
+    id: str
+    scope: ConversationScope
+    domain: str | None = None
+    area: str | None = None
+    content: str
+    created_at: datetime
+    user: UserPublicInfo
+    options: MessageOptions = Field(default_factory=MessageOptions)

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -1,0 +1,106 @@
+"""Tests for the in-memory conversation websocket manager."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from starlette.websockets import WebSocketState
+
+from app.conversations.manager import ConversationWebSocketManager
+from app.conversations.schemas import (
+    ChannelDescriptor,
+    ConversationMessage,
+    MessageOptions,
+    UserPublicInfo,
+)
+
+
+class DummyWebSocket:
+    """Minimal websocket double capturing accepted and sent payloads."""
+
+    def __init__(self) -> None:
+        self.accepted = False
+        self.sent: list[str] = []
+        self.application_state = WebSocketState.CONNECTED
+
+    async def accept(self) -> None:  # pragma: no cover - executed in tests
+        self.accepted = True
+
+    async def send_text(self, data: str) -> None:  # pragma: no cover - executed in tests
+        self.sent.append(data)
+
+
+@pytest.mark.asyncio
+async def test_broadcast_and_history_are_kept_sorted() -> None:
+    manager = ConversationWebSocketManager(history_size=2)
+    channel = ChannelDescriptor.from_params()
+
+    ws_a = DummyWebSocket()
+    ws_b = DummyWebSocket()
+
+    await manager.connect(channel, ws_a)
+    await manager.connect(channel, ws_b)
+
+    base_message = {
+        "domain": channel.domain,
+        "area": channel.area,
+        "scope": channel.scope,
+        "user": UserPublicInfo(id=1, username="tester"),
+        "options": MessageOptions(),
+    }
+
+    message1 = ConversationMessage(
+        id="msg-1",
+        content="Premier message",
+        created_at=datetime.now(timezone.utc),
+        **base_message,
+    )
+    message2 = ConversationMessage(
+        id="msg-2",
+        content="Second message",
+        created_at=datetime.now(timezone.utc),
+        **base_message,
+    )
+    message3 = ConversationMessage(
+        id="msg-3",
+        content="Troisième message",
+        created_at=datetime.now(timezone.utc),
+        **base_message,
+    )
+
+    await manager.broadcast_message(channel, message1)
+    await manager.broadcast_message(channel, message2)
+    await manager.broadcast_message(channel, message3)
+
+    assert ws_a.accepted and ws_b.accepted
+    assert len(ws_a.sent) == 3
+
+    last_payload = json.loads(ws_a.sent[-1])
+    assert last_payload["type"] == "message"
+    assert last_payload["payload"]["id"] == "msg-3"
+
+    history = await manager.history(channel)
+    assert [message.id for message in history] == ["msg-2", "msg-3"]
+
+    ws_c = DummyWebSocket()
+    await manager.connect(channel, ws_c)
+    await manager.send_history(channel, ws_c)
+
+    history_payload = json.loads(ws_c.sent[-1])
+    assert history_payload["type"] == "history"
+    assert [msg["id"] for msg in history_payload["payload"]] == ["msg-2", "msg-3"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_clears_connection() -> None:
+    manager = ConversationWebSocketManager()
+    channel = ChannelDescriptor.from_params(domain="Sciences", area="physique")
+
+    websocket = DummyWebSocket()
+    await manager.connect(channel, websocket)
+    assert await manager.connection_count(channel) == 1
+
+    await manager.disconnect(channel, websocket)
+    assert await manager.connection_count(channel) == 0


### PR DESCRIPTION
## Summary
- add a dedicated conversation websocket endpoint that authenticates users, routes them to general or domain channels, and broadcasts structured messages
- build an in-memory conversation manager and pydantic schemas to keep channel history, expose user metadata, and support extensible message options
- cover the new manager logic with unit tests exercising history retention and connection handling

## Testing
- PYENV_VERSION=3.11.12 python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16656d4a48327b29e12135b1516cf