### PR TITLE
Add itsdangerous dependency for session middleware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ starlette==0.47.1
 stripe==12.5.1
 tiktoken==0.11.0
 websocket-client==1.8.0
+itsdangerous==2.2.0


### PR DESCRIPTION
## Summary
- add the missing `itsdangerous` dependency required by Starlette's session middleware

## Testing
- pytest *(fails: pyenv: version `3.11.9` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d19119daa88327be563a2801d2a5b2