### PR TITLE
Fix feature vote API path to match frontend requests

### DIFF
--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -39,3 +39,4 @@ api_router.include_router(auth_email_router.router, prefix="/auth", tags=["Auth 
 api_router.include_router(resend_webhook_router.router, tags=["Webhooks"])
 api_router.include_router(legal_router.router)
 api_router.include_router(feature_vote_router.router, prefix="/feature-polls", tags=["FeatureVotes"])
+api_router.include_router(feature_vote_router.router, prefix="/feature-votes", tags=["FeatureVotes"])

--- a/app/api/v2/endpoints/feature_vote_router.py
+++ b/app/api/v2/endpoints/feature_vote_router.py
@@ -11,16 +11,30 @@ from app.services.feature_vote_service import FeatureVoteError, FeatureVoteServi
 router = APIRouter()
 
 
-@router.get("/current", response_model=feature_vote_schema.FeaturePollOut)
-def get_active_feature_poll(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
+def _get_active_poll_payload(db: Session, current_user: User) -> feature_vote_schema.FeaturePollOut:
+    """Return the current active poll payload or raise if none exists."""
+
     service = FeatureVoteService(db=db, user=current_user)
     poll = service.get_active_poll()
     if not poll:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="no_active_poll")
     return service.build_poll_payload(poll)
+
+
+@router.get("", response_model=feature_vote_schema.FeaturePollOut)
+def get_active_feature_poll(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return _get_active_poll_payload(db=db, current_user=current_user)
+
+
+@router.get("/current", response_model=feature_vote_schema.FeaturePollOut)
+def get_active_feature_poll_alias(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return _get_active_poll_payload(db=db, current_user=current_user)
 
 
 @router.post("/{poll_id}/votes", response_model=feature_vote_schema.FeaturePollOut)


### PR DESCRIPTION
## Summary
- add a root feature vote endpoint so GET /api/v2/feature-votes returns the active poll
- expose the feature vote router under /feature-votes in addition to the legacy /feature-polls prefix

## Testing
- python -m pytest tests/test_feature_vote_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d396d109f88327b01ac558b3dbb710