### PR TITLE
Reduce deployment size by dropping pgvector dependency

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -36,10 +36,6 @@ from app.admin import (
     UserCapsuleProgressAdmin,
 )
 
-# --- NOUVEL IMPORT ---
-from sqlalchemy import text
-# ---------------------
-
 # --- Configuration du logging ---
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -203,10 +199,6 @@ app.include_router(api_router, prefix="/api/v2")
 async def startup():
     logger.info("Vérification et création des tables de la base de données...")
     async with async_engine.begin() as conn:
-        # --- NOUVEAU BLOC ---
-        # On s'assure que l'extension pgvector est activée
-        await conn.execute(text('CREATE EXTENSION IF NOT EXISTS vector'))
-        # ---------------------
         await conn.run_sync(Base.metadata.create_all)
     logger.info("✅ Les tables de la base de données sont prêtes.")
 

--- a/app/models/analytics/golden_examples_model.py
+++ b/app/models/analytics/golden_examples_model.py
@@ -1,11 +1,14 @@
-from sqlalchemy import Integer, Text, String
+from __future__ import annotations
+
+from sqlalchemy import Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+
 from app.db.base_class import Base
-from pgvector.sqlalchemy import Vector
 
 class GoldenExample(Base):
     __tablename__ = "golden_examples"
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     example_type: Mapped[str] = mapped_column(String(100), index=True) # 'exercise', 'lesson', 'essay_evaluation'
     content: Mapped[str] = mapped_column(Text) # Le contenu JSON ou textuel de l'exemple
-    embedding: Mapped[list[float]] = mapped_column(Vector(384))
+    embedding: Mapped[list[float]] = mapped_column(JSONB)

--- a/app/models/analytics/vector_store_model.py
+++ b/app/models/analytics/vector_store_model.py
@@ -1,10 +1,13 @@
 # Fichier: backend/app/models/analytics/vector_store_model.py (MODIFIÉ)
+from __future__ import annotations
+
+from typing import Any, Dict
+
 from sqlalchemy import String, Text
-from sqlalchemy.dialects.postgresql import JSONB  # <-- 1. Importez JSONB
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
+
 from app.db.base_class import Base
-from pgvector.sqlalchemy import Vector # Assurez-vous d'importer Vector
-from typing import Dict, Any
 
 class VectorStore(Base):
     __tablename__ = 'vector_store'
@@ -14,8 +17,8 @@ class VectorStore(Base):
     # Le texte de la définition (ex: "Apprendre à lire le japonais")
     chunk_text: Mapped[str] = mapped_column(Text, nullable=False)
     
-    # L'embedding de ce texte
-    embedding: Mapped[Vector] = mapped_column(Vector(384), nullable=False) # 384 pour 'all-MiniLM-L6-v2'
+    # L'embedding de ce texte stocké en JSON pour éviter la dépendance pgvector.
+    embedding: Mapped[list[float]] = mapped_column(JSONB, nullable=False)
 
     # --- NOUVELLES COLONNES POUR LA TAXONOMIE ---
     # Ces colonnes stockent la catégorie associée à ce vecteur

--- a/app/services/classification_service.py
+++ b/app/services/classification_service.py
@@ -1,4 +1,4 @@
-"""Utilities for classifying user input against the pgvector store."""
+"""Utilities for classifying user input against the vector store."""
 
 from __future__ import annotations
 

--- a/app/services/rag_utils.py
+++ b/app/services/rag_utils.py
@@ -1,11 +1,16 @@
 # Fichier: backend/app/services/rag_utils.py (VERSION CORRIGÉE)
 
 import logging
-from sqlalchemy.orm import Session
-from sqlalchemy import select
+from typing import List, Tuple
 
-# ---------------------------------
+from sqlalchemy.orm import Session
+
 from app.core import ai_service
+from app.core.embeddings import (
+    cosine_similarity,
+    ensure_dimension,
+    normalize_vector,
+)
 from app.models.analytics.vector_store_model import VectorStore
 
 logger = logging.getLogger(__name__)
@@ -25,25 +30,45 @@ def _find_similar_examples(db: Session, topic: str, language: str, content_type:
     """
     try:
         # Utilise maintenant la fonction get_embedding locale pour la cohérence
-        topic_embedding = get_embedding(topic)
-        
-        similar_examples = db.scalars(
-            select(VectorStore)
-            .filter(VectorStore.source_language == language)
-            .filter(VectorStore.content_type == content_type)
-            .order_by(VectorStore.embedding.l2_distance(topic_embedding))
-            .limit(limit)
-        ).all()
-
-        if not similar_examples:
-            logger.info(f"Aucun exemple RAG trouvé pour '{topic}' avec le type '{content_type}'.")
+        topic_embedding = normalize_vector(get_embedding(topic))
+        if not any(topic_embedding):
+            logger.info("Embedding vide pour le sujet '%s', aucun contexte RAG retourné.", topic)
             return ""
 
+        candidates: List[VectorStore] = (
+            db.query(VectorStore)
+            .filter(VectorStore.source_language == language)
+            .filter(VectorStore.content_type == content_type)
+            .all()
+        )
+
+        scored: List[Tuple[VectorStore, float]] = []
+        for entry in candidates:
+            raw_embedding = entry.embedding or []
+            if not raw_embedding:
+                continue
+
+            aligned = normalize_vector(ensure_dimension(raw_embedding, len(topic_embedding)))
+            similarity = cosine_similarity(topic_embedding, aligned)
+            if similarity <= 0:
+                continue
+            scored.append((entry, similarity))
+
+        if not scored:
+            logger.info(
+                "Aucun exemple RAG trouvé pour '%s' avec le type '%s'.",
+                topic,
+                content_type,
+            )
+            return ""
+
+        top_matches = [entry for entry, _ in sorted(scored, key=lambda item: item[1], reverse=True)[:limit]]
+
         context = "Voici des exemples de haute qualité pour t'inspirer. Suis leur style, leur ton et leur structure :\n\n"
-        for i, ex in enumerate(similar_examples):
+        for i, ex in enumerate(top_matches):
             context += f"--- EXEMPLE {i+1} ---\n{ex.chunk_text}\n\n"
-        
-        logger.info(f"{len(similar_examples)} exemples RAG trouvés pour '{topic}'.")
+
+        logger.info("%s exemples RAG trouvés pour '%s'.", len(top_matches), topic)
         return context
     except Exception as e:
         logger.error(f"Erreur lors de la recherche RAG pour '{topic}': {e}", exc_info=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 openai==1.98.0
 passlib[bcrypt]==1.7.4
-pgvector==0.4.1
 psycopg2-binary==2.9.10
 pydantic==2.11.7
 pydantic-settings==2.10.1

--- a/seed_vector_store.py
+++ b/seed_vector_store.py
@@ -6,8 +6,6 @@ from app.db.session import SessionLocal
 from app.models.analytics.vector_store_model import VectorStore
 from app.core.ai_service import get_text_embedding
 from app.core.embeddings import EMBEDDING_DIMENSION
-from sqlalchemy import text
-from app.db.base import Base 
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -19,15 +17,10 @@ EXAMPLES_FILEPATH = "app/data/vector.json"
 VECTOR_DIMENSION = EMBEDDING_DIMENSION
 
 def setup_database_extension(db: Session):
-    """S'assure que l'extension pgvector est activée."""
-    try:
-        db.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
-        db.commit()
-        logger.info("L'extension 'vector' de PostgreSQL est activée.")
-    except Exception as e:
-        logger.error(f"Impossible d'activer l'extension 'vector'. Assurez-vous qu'elle est installée. Erreur: {e}")
-        db.rollback()
-        raise
+    """Compatibilité ascendante : plus nécessaire avec le stockage JSON."""
+    logger.info(
+        "Stockage des embeddings via JSONB : aucune extension 'vector' n'est requise."
+    )
 
 def clear_vector_store(db: Session):
     """Vide la table vector_store pour éviter les doublons lors du re-peuplement."""

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,7 @@
   "functions": {
     "api/index.py": {
       "runtime": "@vercel/python@5.0.5",
-      "maxDuration": 15,
-      "memory": 1024
+      "maxDuration": 15
     }
   },
   "routes": [


### PR DESCRIPTION
## Summary
- store vector embeddings in JSONB columns and remove the pgvector dependency to shrink the deployed package
- recompute similarity scores in Python within AI helpers now that database-level vector operators are gone
- drop the unused pgvector extension setup and clean up the Vercel config warning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3c2a6f2708327bb8b9a7e4dcf7d8c