### PR TITLE
Normalize header tokens and harden password verification

### DIFF
--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,10 +1,14 @@
 # Fichier: nanshe/backend/app/core/security.py (CORRIGÉ)
 
+import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Union
+
 from jose import jwt
+from passlib import exc as passlib_exc
 from passlib.context import CryptContext
-from app.core.config import settings 
+
+from app.core.config import settings
 
 # --- Configuration de la Sécurité ---
 SECRET_KEY = settings.SECRET_KEY
@@ -12,6 +16,7 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+logger = logging.getLogger(__name__)
 
 # --- Fonctions Utilitaires ---
 def create_access_token(subject: Union[str, Any], expires_delta: timedelta = None) -> str:
@@ -25,10 +30,22 @@ def create_access_token(subject: Union[str, Any], expires_delta: timedelta = Non
     encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 
-def verify_password(plain_password: str, hashed_password: str) -> bool:
+def verify_password(plain_password: str | None, hashed_password: str | None) -> bool:
     """Vérifie si un mot de passe en clair correspond à un mot de passe haché."""
-    return pwd_context.verify(plain_password, hashed_password)
+
+    if not plain_password or not hashed_password:
+        return False
+
+    try:
+        return pwd_context.verify(plain_password, hashed_password)
+    except (ValueError, TypeError, passlib_exc.PasslibError) as exc:
+        logger.warning("Password verification failed: %s", exc)
+        return False
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.error("Unexpected password verification error: %s", exc)
+        return False
 
 def get_password_hash(password: str) -> str:
     """Hache un mot de passe."""
     return pwd_context.hash(password)
+


### PR DESCRIPTION
## Summary
- normalize tokens extracted from cookies, headers, and query params before decoding them
- iterate through multiple token sources so header values can override stale cookies and add broader fallbacks
- guard password verification against invalid hashes to avoid admin login crashes

## Testing
- PYENV_VERSION=3.11.12 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40eba6ba4832797a3ac5e7614a972