### PR TITLE
Improve environment validation diagnostics

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for the Nanshe project."""

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -1,0 +1,30 @@
+"""CLI helper to validate required environment variables.
+
+Usage::
+
+    python -m scripts.check_env
+
+It simply imports :mod:`app.core.config` and reports any validation errors in a
+readable format, exiting with status code 1 when something is missing.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from pydantic import ValidationError
+
+try:
+    from app.core.config import settings
+except ValidationError as exc:
+    # ``app.core.config`` already prints a detailed error summary, so we only
+    # need to set a non-zero exit code here.
+    print("Environment validation failed – see details above.", file=sys.stderr)
+    sys.exit(1)
+else:
+    print("Environment variables OK.")
+    for name, value in settings.model_dump().items():
+        if "key" in name.lower() or "password" in name.lower():
+            print(f"- {name}: <hidden>")
+        else:
+            print(f"- {name}: {value}")


### PR DESCRIPTION
## Summary
- log structured messages when the Settings model fails to load missing environment variables
- add a reusable scripts.check_env helper to validate the configuration locally or in CI

## Testing
- poetry run pytest *(fails: The Poetry configuration is invalid: Either [project.name] or [tool.poetry.name] is required in package mode.)*

------
https://chatgpt.com/codex/tasks/task_e_68d41e2056348327a443e3ba830a4308