### PR TITLE
Handle Supabase self-signed certificates for asyncpg

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,6 +1,8 @@
 # Fichier: backend/app/db/session.py (VERSION FINALE)
 from __future__ import annotations
 
+import ssl
+
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy import create_engine
 from sqlalchemy.engine.url import make_url
@@ -9,7 +11,34 @@ from sqlalchemy.orm import sessionmaker
 from app.core.config import settings
 
 
-def _prepare_asyncpg_connection(url: str) -> tuple[str, dict]:
+def _create_ssl_context(
+    mode: str,
+    root_cert: str | None,
+    client_cert: str | None,
+    client_key: str | None,
+) -> ssl.SSLContext:
+    """Create an :class:`ssl.SSLContext` matching libpq ``sslmode`` semantics."""
+
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+
+    if root_cert:
+        context.load_verify_locations(cafile=root_cert)
+
+    if client_cert:
+        context.load_cert_chain(certfile=client_cert, keyfile=client_key)
+
+    if mode in {"verify-ca", "verify-full"}:
+        context.check_hostname = mode == "verify-full"
+    else:
+        # ``require``/``prefer``/``allow`` should only ensure encryption, mirroring
+        # libpq's behaviour where certificate validation is skipped.
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+
+    return context
+
+
+def _prepare_asyncpg_connection(url: str) -> tuple[str, dict[str, object]]:
     """Strip unsupported query params from asyncpg URLs.
 
     Providers such as Supabase append ``sslmode=require`` to their connection
@@ -19,8 +48,8 @@ def _prepare_asyncpg_connection(url: str) -> tuple[str, dict]:
 
     We remove this parameter for the async engine while keeping it on the
     original URL (used by the synchronous psycopg engine where ``sslmode`` is
-    valid) and translate common ``sslmode`` values to the boolean ``ssl`` flag
-    expected by asyncpg.
+    valid) and translate common ``sslmode`` values to an ``ssl`` argument that
+    mirrors libpq's behaviour for ``asyncpg``.
     """
 
     try:
@@ -33,20 +62,32 @@ def _prepare_asyncpg_connection(url: str) -> tuple[str, dict]:
 
     query = dict(parsed_url.query)
     sslmode = query.pop("sslmode", None)
+    sslrootcert = query.pop("sslrootcert", None)
+    sslcert = query.pop("sslcert", None)
+    sslkey = query.pop("sslkey", None)
 
     connect_args: dict[str, object] = {}
     if isinstance(sslmode, str):
         sslmode_normalized = sslmode.lower()
-        ssl_mapping = {
-            "disable": False,
-            "allow": True,
-            "prefer": True,
-            "require": True,
-            "verify-ca": True,
-            "verify-full": True,
-        }
-        if sslmode_normalized in ssl_mapping:
-            connect_args["ssl"] = ssl_mapping[sslmode_normalized]
+
+        if sslmode_normalized == "disable":
+            connect_args["ssl"] = False
+        elif sslmode_normalized in {"allow", "prefer", "require", "verify-ca", "verify-full"}:
+            connect_args["ssl"] = _create_ssl_context(
+                sslmode_normalized,
+                root_cert=sslrootcert,
+                client_cert=sslcert,
+                client_key=sslkey,
+            )
+
+    elif sslrootcert or sslcert:
+        # libpq enables TLS implicitly when any certificate paths are provided.
+        connect_args["ssl"] = _create_ssl_context(
+            "require",
+            root_cert=sslrootcert,
+            client_cert=sslcert,
+            client_key=sslkey,
+        )
 
     sanitized_url = parsed_url.set(query=query).render_as_string(hide_password=False)
     return sanitized_url, connect_args


### PR DESCRIPTION
## Summary
- align the asyncpg connection setup with libpq sslmode semantics by creating custom SSL contexts
- support sslrootcert/sslcert/sslkey parameters so self-signed Supabase certificates can connect without verification errors

## Testing
- PYENV_VERSION=3.11.12 pytest

------
https://chatgpt.com/codex/tasks/task_e_68d467b9ffac8327a75564529ea7b16c