### PR TITLE
Allow users to persist profile customization

### DIFF
--- a/app/api/v2/endpoints/user_router.py
+++ b/app/api/v2/endpoints/user_router.py
@@ -126,6 +126,18 @@ async def update_me(
             current_user.full_name = new_full_name
             has_changes = True
 
+    if payload.active_title is not None:
+        new_active_title = payload.active_title.strip() or None
+        if new_active_title != current_user.active_title:
+            current_user.active_title = new_active_title
+            has_changes = True
+
+    if payload.profile_border_color is not None:
+        new_border_color = payload.profile_border_color.strip() or None
+        if new_border_color != current_user.profile_border_color:
+            current_user.profile_border_color = new_border_color
+            has_changes = True
+
     if payload.username is not None:
         new_username = payload.username.strip()
         if not new_username:

--- a/app/schemas/user/user_schema.py
+++ b/app/schemas/user/user_schema.py
@@ -23,6 +23,8 @@ class UserUpdate(BaseModel):
     email: Optional[EmailStr] = None
     username: Optional[str] = None
     full_name: Optional[str] = None
+    active_title: Optional[str] = None
+    profile_border_color: Optional[str] = None
 
 # --- Schéma pour la Réponse de l'API ---
 # C'est la forme des données utilisateur que l'API renverra.

--- a/tests/test_user_account_settings.py
+++ b/tests/test_user_account_settings.py
@@ -43,6 +43,36 @@ async def test_update_me_updates_core_fields(monkeypatch, db_session):
 
 
 @pytest.mark.asyncio
+async def test_update_me_updates_profile_customization(db_session):
+    user = create_user(
+        db_session,
+        username="profiled",
+        email="profiled@example.com",
+        active_title=None,
+        profile_border_color=None,
+    )
+
+    payload = UserUpdate(
+        active_title="  Explorateur  ",
+        profile_border_color="  #123abc  ",
+    )
+
+    request = SimpleNamespace(headers={})
+
+    updated_user = await user_router.update_me(payload, request, db_session, user)
+
+    assert updated_user.active_title == "Explorateur"
+    assert updated_user.profile_border_color == "#123abc"
+
+    # Mettre à jour une deuxième fois pour vérifier la suppression
+    payload = UserUpdate(active_title="  ", profile_border_color="  ")
+    updated_user = await user_router.update_me(payload, request, db_session, user)
+
+    assert updated_user.active_title is None
+    assert updated_user.profile_border_color is None
+
+
+@pytest.mark.asyncio
 async def test_update_me_prevents_duplicate_email(monkeypatch, db_session):
     user = create_user(
         db_session,


### PR DESCRIPTION
## Summary
- allow profile updates to persist active_title and profile_border_color on the /users/me endpoint
- extend the UserUpdate schema so profile customization fields can be provided by the client
- cover the new behaviour with tests that verify storing and clearing custom titles and border colours

## Testing
- PYENV_VERSION=3.11.12 pytest tests/test_user_account_settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d495c62e8c8327b398d5bf7b739eae