### PR TITLE
Save coach conversations by context

### DIFF
--- a/app/api/v2/endpoints/toolbox_router.py
+++ b/app/api/v2/endpoints/toolbox_router.py
@@ -3,8 +3,15 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from app.api.v2.dependencies import get_db, get_current_user
 from app.models.user.user_model import User
-from app.crud import toolbox_crud, toolbox_notes_crud, coach_energy_crud
+from app.crud import (
+    coach_conversation_crud,
+    coach_energy_crud,
+    toolbox_crud,
+    toolbox_notes_crud,
+)
 from app.schemas.toolbox import (
+    CoachConversationMessageOut,
+    CoachConversationThreadOut,
     MoleculeNoteCreate,
     MoleculeNoteOut,
     MoleculeNoteUpdate,
@@ -52,6 +59,45 @@ def get_coach_energy(
     current_user: User = Depends(get_current_user),
 ):
     return coach_energy_crud.get_energy_status(db, current_user)
+
+
+@router.get("/coach/conversations", response_model=list[CoachConversationThreadOut])
+def list_coach_conversations(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[CoachConversationThreadOut]:
+    threads = coach_conversation_crud.list_threads_for_user(db, current_user)
+    stats = coach_conversation_crud.fetch_thread_statistics(db, (thread.id for thread in threads))
+
+    result: list[CoachConversationThreadOut] = []
+    for thread in threads:
+        message_count, last_message_at = stats.get(thread.id, (0, None))
+        result.append(
+            CoachConversationThreadOut.from_thread(
+                thread,
+                message_count=message_count,
+                last_message_at=last_message_at,
+            )
+        )
+    return result
+
+
+@router.get(
+    "/coach/conversations/{thread_id}/messages",
+    response_model=list[CoachConversationMessageOut],
+)
+def list_coach_conversation_messages(
+    thread_id: int,
+    limit: int | None = Query(default=None, ge=1, le=500),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[CoachConversationMessageOut]:
+    thread = coach_conversation_crud.get_thread_for_user(db, current_user, thread_id)
+    if not thread:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation introuvable")
+
+    messages = coach_conversation_crud.list_messages_for_thread(db, thread, limit=limit)
+    return messages
 
 
 def _serialize_note(note: MoleculeNote) -> MoleculeNoteOut:

--- a/app/crud/coach_conversation_crud.py
+++ b/app/crud/coach_conversation_crud.py
@@ -1,0 +1,210 @@
+"""Persistence helpers for coach IA conversations grouped by location."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.capsule.capsule_model import Capsule
+from app.models.capsule.granule_model import Granule
+from app.models.capsule.molecule_model import Molecule
+from app.models.toolbox.coach_conversation_model import (
+    CoachConversationLocation,
+    CoachConversationMessage,
+    CoachConversationRole,
+    CoachConversationThread,
+)
+from app.models.user.user_model import User
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def determine_location(
+    *,
+    capsule: Capsule | None,
+    molecule: Molecule | None,
+) -> tuple[CoachConversationLocation, int | None, int | None]:
+    """Return the location enum and associated identifiers for the conversation."""
+
+    if molecule is not None:
+        capsule_from_molecule = getattr(getattr(molecule, "granule", None), "capsule", None)
+        capsule_id = getattr(capsule_from_molecule, "id", None)
+        return CoachConversationLocation.MOLECULE, capsule_id, molecule.id
+
+    if capsule is not None:
+        return CoachConversationLocation.CAPSULE, capsule.id, None
+
+    return CoachConversationLocation.DASHBOARD, None, None
+
+
+def get_or_create_thread(
+    db: Session,
+    user: User,
+    *,
+    location: CoachConversationLocation,
+    capsule_id: int | None,
+    molecule_id: int | None,
+) -> CoachConversationThread:
+    """Return an existing thread for the given location or create it."""
+
+    location_key = CoachConversationThread.build_location_key(
+        location=location, capsule_id=capsule_id, molecule_id=molecule_id
+    )
+
+    thread = (
+        db.query(CoachConversationThread)
+        .filter(
+            CoachConversationThread.user_id == user.id,
+            CoachConversationThread.location_key == location_key,
+        )
+        .first()
+    )
+    if thread:
+        return thread
+
+    thread = CoachConversationThread(
+        user_id=user.id,
+        location=location,
+        location_key=location_key,
+        capsule_id=capsule_id,
+        molecule_id=molecule_id,
+    )
+    db.add(thread)
+    db.commit()
+    db.refresh(thread)
+    return thread
+
+
+def append_message(
+    db: Session,
+    thread: CoachConversationThread,
+    *,
+    role: CoachConversationRole,
+    content: str,
+    payload: dict | None = None,
+) -> CoachConversationMessage:
+    """Persist a new message and update the thread timestamp."""
+
+    message = CoachConversationMessage(
+        thread_id=thread.id,
+        role=role,
+        content=content,
+        payload=payload,
+    )
+    thread.updated_at = _now()
+
+    db.add_all([thread, message])
+    db.commit()
+    db.refresh(message)
+    return message
+
+
+def append_user_message(
+    db: Session,
+    thread: CoachConversationThread,
+    *,
+    content: str,
+    payload: dict | None = None,
+) -> CoachConversationMessage:
+    return append_message(db, thread, role=CoachConversationRole.USER, content=content, payload=payload)
+
+
+def append_coach_message(
+    db: Session,
+    thread: CoachConversationThread,
+    *,
+    content: str,
+    payload: dict | None = None,
+) -> CoachConversationMessage:
+    return append_message(db, thread, role=CoachConversationRole.COACH, content=content, payload=payload)
+
+
+def list_threads_for_user(db: Session, user: User) -> list[CoachConversationThread]:
+    """Return every conversation thread available to ``user`` sorted by recency."""
+
+    return (
+        db.query(CoachConversationThread)
+        .options(
+            joinedload(CoachConversationThread.capsule),
+            joinedload(CoachConversationThread.molecule).joinedload(Molecule.granule).joinedload(Granule.capsule),
+        )
+        .filter(CoachConversationThread.user_id == user.id)
+        .order_by(CoachConversationThread.updated_at.desc())
+        .all()
+    )
+
+
+def get_thread_for_user(db: Session, user: User, thread_id: int) -> CoachConversationThread | None:
+    return (
+        db.query(CoachConversationThread)
+        .options(
+            joinedload(CoachConversationThread.capsule),
+            joinedload(CoachConversationThread.molecule).joinedload(Molecule.granule).joinedload(Granule.capsule),
+        )
+        .filter(
+            CoachConversationThread.id == thread_id,
+            CoachConversationThread.user_id == user.id,
+        )
+        .first()
+    )
+
+
+def list_messages_for_thread(
+    db: Session,
+    thread: CoachConversationThread,
+    *,
+    limit: int | None = None,
+) -> list[CoachConversationMessage]:
+    """Return messages ordered from oldest to newest for a thread."""
+
+    query = (
+        db.query(CoachConversationMessage)
+        .filter(CoachConversationMessage.thread_id == thread.id)
+        .order_by(CoachConversationMessage.created_at.asc(), CoachConversationMessage.id.asc())
+    )
+    if limit is not None:
+        query = query.limit(limit)
+    return query.all()
+
+
+def fetch_thread_statistics(
+    db: Session, thread_ids: Iterable[int]
+) -> dict[int, tuple[int, datetime | None]]:
+    """Return (message_count, last_message_at) per thread id."""
+
+    thread_ids = list(thread_ids)
+    if not thread_ids:
+        return {}
+
+    rows = (
+        db.query(
+            CoachConversationMessage.thread_id,
+            func.count(CoachConversationMessage.id),
+            func.max(CoachConversationMessage.created_at),
+        )
+        .filter(CoachConversationMessage.thread_id.in_(thread_ids))
+        .group_by(CoachConversationMessage.thread_id)
+        .all()
+    )
+
+    stats: dict[int, tuple[int, datetime | None]] = {}
+    for thread_id, message_count, last_message_at in rows:
+        stats[int(thread_id)] = (int(message_count), last_message_at)
+    return stats
+
+
+def bulk_delete_threads(db: Session, threads: Iterable[CoachConversationThread]) -> int:
+    """Delete multiple conversation threads. Returns the number of deleted threads."""
+
+    count = 0
+    for thread in threads:
+        db.delete(thread)
+        count += 1
+    if count:
+        db.commit()
+    return count

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -41,6 +41,10 @@ from app.models.analytics.classification_feedback_model import ClassificationFee
 from app.models.analytics.ai_token_log_model import AITokenLog
 from app.models.toolbox.molecule_note_model import MoleculeNote
 from app.models.toolbox.coach_energy_model import CoachEnergyWallet
+from app.models.toolbox.coach_conversation_model import (
+    CoachConversationMessage,
+    CoachConversationThread,
+)
 from app.models.vote.feature_vote_model import FeaturePoll, FeaturePollOption, FeaturePollVote
 
 __all__ = (
@@ -75,6 +79,8 @@ __all__ = (
     "MoleculeNote",
     "ClassificationFeedback",
     "CoachEnergyWallet",
+    "CoachConversationThread",
+    "CoachConversationMessage",
     "FeaturePoll",
     "FeaturePollOption",
     "FeaturePollVote",

--- a/app/models/toolbox/coach_conversation_model.py
+++ b/app/models/toolbox/coach_conversation_model.py
@@ -1,0 +1,100 @@
+"""Database models for storing coach IA conversations by context."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, Enum as EnumSQL, ForeignKey, Integer, JSON, String, Text, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base_class import Base
+
+
+class CoachConversationLocation(str, enum.Enum):
+    """Different contexts supported by the coach conversation threads."""
+
+    DASHBOARD = "dashboard"
+    CAPSULE = "capsule"
+    MOLECULE = "molecule"
+
+
+class CoachConversationRole(str, enum.Enum):
+    """Role of a message author inside a conversation thread."""
+
+    USER = "user"
+    COACH = "coach"
+
+
+class CoachConversationThread(Base):
+    """Group messages for a user and a specific location (dashboard/capsule/molecule)."""
+
+    __tablename__ = "coach_conversation_threads"
+    __table_args__ = (
+        UniqueConstraint("user_id", "location_key", name="uq_coach_conversation_location"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    location: Mapped[CoachConversationLocation] = mapped_column(
+        EnumSQL(CoachConversationLocation, name="coach_conversation_location"), nullable=False
+    )
+    location_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    capsule_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("capsules.id", ondelete="SET NULL"), nullable=True)
+    molecule_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("molecules.id", ondelete="SET NULL"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    user = relationship("User", back_populates="coach_conversation_threads")
+    capsule = relationship("Capsule")
+    molecule = relationship("Molecule")
+    messages = relationship(
+        "CoachConversationMessage",
+        back_populates="thread",
+        cascade="all, delete-orphan",
+        order_by="CoachConversationMessage.created_at",
+    )
+
+    @staticmethod
+    def build_location_key(
+        *,
+        location: CoachConversationLocation,
+        capsule_id: int | None = None,
+        molecule_id: int | None = None,
+    ) -> str:
+        if location == CoachConversationLocation.DASHBOARD:
+            return "dashboard"
+        if location == CoachConversationLocation.CAPSULE:
+            if capsule_id is None:
+                raise ValueError("capsule_id is required for capsule conversations")
+            return f"capsule:{capsule_id}"
+        if location == CoachConversationLocation.MOLECULE:
+            if molecule_id is None:
+                raise ValueError("molecule_id is required for molecule conversations")
+            return f"molecule:{molecule_id}"
+        raise ValueError(f"Unsupported conversation location: {location}")
+
+
+class CoachConversationMessage(Base):
+    """Persist individual messages exchanged between the user and the coach."""
+
+    __tablename__ = "coach_conversation_messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    thread_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("coach_conversation_threads.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    role: Mapped[CoachConversationRole] = mapped_column(
+        EnumSQL(CoachConversationRole, name="coach_conversation_role"), nullable=False
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    thread = relationship("CoachConversationThread", back_populates="messages")

--- a/app/models/user/user_model.py
+++ b/app/models/user/user_model.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from ..progress.user_activity_log_model import UserActivityLog
     from ..analytics.classification_feedback_model import ClassificationFeedback
     from ..toolbox.coach_energy_model import CoachEnergyWallet
+    from ..toolbox.coach_conversation_model import CoachConversationThread
 
 # On définit l'énumération pour le statut d'abonnement
 class SubscriptionStatus(str, enum.Enum):
@@ -74,6 +75,9 @@ class User(Base):
     )
     coach_energy_wallet: Mapped["CoachEnergyWallet"] = relationship(
         back_populates="user", cascade="all, delete-orphan", uselist=False
+    )
+    coach_conversation_threads: Mapped[List["CoachConversationThread"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
     )
     
     @property

--- a/app/schemas/toolbox/__init__.py
+++ b/app/schemas/toolbox/__init__.py
@@ -1,10 +1,18 @@
 """Schemas pour les fonctionnalités de la toolbox."""
 
 from .note_schema import MoleculeNoteBase, MoleculeNoteCreate, MoleculeNoteUpdate, MoleculeNoteOut
+from .coach_conversation_schema import (
+    CoachConversationMessageOut,
+    CoachConversationThreadList,
+    CoachConversationThreadOut,
+)
 
 __all__ = (
     "MoleculeNoteBase",
     "MoleculeNoteCreate",
     "MoleculeNoteUpdate",
     "MoleculeNoteOut",
+    "CoachConversationMessageOut",
+    "CoachConversationThreadOut",
+    "CoachConversationThreadList",
 )

--- a/app/schemas/toolbox/coach_conversation_schema.py
+++ b/app/schemas/toolbox/coach_conversation_schema.py
@@ -1,0 +1,78 @@
+"""Pydantic schemas exposing the coach IA conversation data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.toolbox.coach_conversation_model import (
+    CoachConversationLocation,
+    CoachConversationRole,
+    CoachConversationThread,
+)
+
+
+class CoachConversationMessageOut(BaseModel):
+    """Serialized representation of a stored conversation message."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    thread_id: int
+    role: CoachConversationRole
+    content: str
+    payload: Optional[Dict[str, Any]] = None
+    created_at: datetime
+
+
+class CoachConversationThreadOut(BaseModel):
+    """Serialized conversation thread with contextual metadata."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    location: CoachConversationLocation
+    capsule_id: int | None = None
+    capsule_title: str | None = Field(default=None)
+    molecule_id: int | None = None
+    molecule_title: str | None = Field(default=None)
+    updated_at: datetime
+    created_at: datetime
+    last_message_at: datetime | None = None
+    message_count: int = 0
+
+    @classmethod
+    def from_thread(
+        cls,
+        thread: CoachConversationThread,
+        *,
+        message_count: int,
+        last_message_at: datetime | None,
+    ) -> "CoachConversationThreadOut":
+        return cls(
+            id=thread.id,
+            location=thread.location,
+            capsule_id=thread.capsule_id,
+            capsule_title=getattr(thread.capsule, "title", None),
+            molecule_id=thread.molecule_id,
+            molecule_title=getattr(thread.molecule, "title", None),
+            updated_at=thread.updated_at,
+            created_at=thread.created_at,
+            last_message_at=last_message_at,
+            message_count=message_count,
+        )
+
+
+class CoachConversationThreadList(BaseModel):
+    """Response model containing multiple threads."""
+
+    threads: List[CoachConversationThreadOut]
+
+
+__all__ = [
+    "CoachConversationMessageOut",
+    "CoachConversationThreadOut",
+    "CoachConversationThreadList",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,10 @@ from app.models.progress.user_answer_log_model import UserAnswerLog
 from app.models.progress.user_atomic_progress import UserAtomProgress
 from app.models.progress.user_course_progress_model import UserCourseProgress
 from app.models.toolbox.coach_energy_model import CoachEnergyWallet
+from app.models.toolbox.coach_conversation_model import (
+    CoachConversationMessage,
+    CoachConversationThread,
+)
 from app.models.vote.feature_vote_model import FeaturePoll, FeaturePollOption, FeaturePollVote
 from app.models.email.email_token import EmailToken
 
@@ -72,6 +76,8 @@ TABLES = [
     ContentFeedback.__table__,
     ContentFeedbackDetail.__table__,
     CoachEnergyWallet.__table__,
+    CoachConversationThread.__table__,
+    CoachConversationMessage.__table__,
     EmailToken.__table__,
     Notification.__table__,
     Badge.__table__,

--- a/tests/test_coach_conversations.py
+++ b/tests/test_coach_conversations.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from app.core import ai_service
+from app.crud import coach_conversation_crud, toolbox_crud
+from app.models.toolbox.coach_conversation_model import CoachConversationLocation
+from tests.utils import create_capsule_graph, create_user
+
+
+def _stub_ai_response(monkeypatch, response_text: str = "Réponse du coach") -> None:
+    payload = {
+        "response": response_text,
+        "suggestions": ["Suggestion"],
+        "next_steps": ["Étape suivante"],
+    }
+
+    def _fake_call_ai_and_log(**_: dict):
+        return payload
+
+    monkeypatch.setattr(ai_service, "call_ai_and_log", _fake_call_ai_and_log)
+
+
+def test_ask_coach_persists_messages_with_location(db_session, monkeypatch) -> None:
+    user = create_user(db_session, username="coach_user")
+    capsule, molecule, *_ = create_capsule_graph(db_session, user.id)
+
+    _stub_ai_response(monkeypatch, response_text="Analyse détaillée")
+
+    result = toolbox_crud.ask_coach(
+        db=db_session,
+        user=user,
+        message="Bonjour coach !",
+        context={"capsuleId": capsule.id, "moleculeId": molecule.id},
+        history=[],
+        quick_action=None,
+        selection=None,
+    )
+
+    assert result["response"] == "Analyse détaillée"
+    assert result["thread_id"]
+
+    threads = coach_conversation_crud.list_threads_for_user(db_session, user)
+    assert len(threads) == 1
+
+    thread = threads[0]
+    assert thread.location == CoachConversationLocation.MOLECULE
+    assert thread.capsule_id == capsule.id
+    assert thread.molecule_id == molecule.id
+
+    messages = coach_conversation_crud.list_messages_for_thread(db_session, thread)
+    assert len(messages) == 2
+    assert messages[0].role.value == "user"
+    assert messages[0].content == "Bonjour coach !"
+    assert messages[1].role.value == "coach"
+    assert messages[1].content == "Analyse détaillée"
+    assert messages[1].payload["raw_response"]["suggestions"] == ["Suggestion"]
+
+    stats = coach_conversation_crud.fetch_thread_statistics(db_session, [thread.id])
+    count, last_message_at = stats[thread.id]
+    assert count == 2
+    assert last_message_at == messages[-1].created_at
+
+
+def test_conversations_are_partitioned_by_location(db_session, monkeypatch) -> None:
+    user = create_user(db_session, username="multi_context")
+    capsule, molecule, *_ = create_capsule_graph(db_session, user.id)
+
+    _stub_ai_response(monkeypatch, response_text="Réponse générique")
+
+    # Dashboard conversation
+    toolbox_crud.ask_coach(
+        db=db_session,
+        user=user,
+        message="Salut du dashboard",
+        context={"path": "/dashboard"},
+        history=[],
+        quick_action=None,
+        selection=None,
+    )
+
+    # Capsule level conversation
+    toolbox_crud.ask_coach(
+        db=db_session,
+        user=user,
+        message="Question capsule",
+        context={"capsuleId": capsule.id},
+        history=[],
+        quick_action=None,
+        selection=None,
+    )
+
+    # Molecule conversation (two messages to ensure reuse)
+    toolbox_crud.ask_coach(
+        db=db_session,
+        user=user,
+        message="Question molécule",
+        context={"capsuleId": capsule.id, "moleculeId": molecule.id},
+        history=[],
+        quick_action=None,
+        selection=None,
+    )
+    toolbox_crud.ask_coach(
+        db=db_session,
+        user=user,
+        message="Relance molécule",
+        context={"moleculeId": molecule.id},
+        history=[],
+        quick_action=None,
+        selection=None,
+    )
+
+    threads = coach_conversation_crud.list_threads_for_user(db_session, user)
+    assert len(threads) == 3
+
+    by_signature = {
+        (thread.location, thread.capsule_id, thread.molecule_id): thread for thread in threads
+    }
+
+    assert (CoachConversationLocation.DASHBOARD, None, None) in by_signature
+    assert (CoachConversationLocation.CAPSULE, capsule.id, None) in by_signature
+    assert (CoachConversationLocation.MOLECULE, capsule.id, molecule.id) in by_signature
+
+    molecule_thread = by_signature[(CoachConversationLocation.MOLECULE, capsule.id, molecule.id)]
+    molecule_messages = coach_conversation_crud.list_messages_for_thread(db_session, molecule_thread)
+    assert len(molecule_messages) == 4
+    assert [msg.role.value for msg in molecule_messages] == ["user", "coach", "user", "coach"]
+
+    stats = coach_conversation_crud.fetch_thread_statistics(db_session, [thread.id for thread in threads])
+    molecule_stats = stats[molecule_thread.id]
+    assert molecule_stats[0] == 4
+    assert molecule_stats[1] == molecule_messages[-1].created_at


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and CRUD utilities to persist coach conversations per dashboard, capsule, or molecule context
- capture coach exchanges in toolbox logic, return thread identifiers, and expose listing endpoints for saved threads and messages
- extend test fixtures and add coverage ensuring conversations stay partitioned by location while fixing timezone handling for energy regen

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5a7bdcaec8327b03c7571bd04084e