### PR TITLE
Allow HTMX headers in CORS configuration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -135,11 +135,22 @@ def _build_cors_config() -> tuple[list[str], re.Pattern[str] | None]:
 app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
 
 cors_origins, cors_regex = _build_cors_config()
+_HTMX_HEADERS = {
+    "HX-Request",
+    "HX-Target",
+    "HX-Trigger",
+    "HX-Trigger-Name",
+    "HX-Current-URL",
+    "HX-History-Restore-Request",
+}
+
+cors_headers = {"Authorization", "Content-Type", "X-App-Lang"} | _HTMX_HEADERS
+
 cors_kwargs: dict[str, object] = {
     "allow_origins": cors_origins,
     "allow_credentials": True,
     "allow_methods": ["*"],
-    "allow_headers": ["Authorization", "Content-Type", "X-App-Lang"],
+    "allow_headers": sorted(cors_headers),
 }
 
 if cors_regex is not None:


### PR DESCRIPTION
## Summary
- allow the SQLAdmin back-office HTMX headers in the CORS middleware so admin AJAX requests succeed on Vercel

## Testing
- not run (pyenv-managed Python 3.11.9 required for pytest is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d6578fbcec8327b31baa40cd309d44