### PR TITLE
feat: sync training data vectors with supabase on startup

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -29,6 +29,16 @@ class Settings(BaseSettings):
     EMAIL_RESET_TTL_MIN: int = 30
     RESEND_WEBHOOK_SECRET: str | None = None
 
+    # --- Supabase Vector Store configuration ---
+    SUPABASE_URL: AnyHttpUrl | None = None
+    SUPABASE_SERVICE_ROLE_KEY: str | None = None
+    SUPABASE_VECTOR_TABLE: str = "vector_store"
+    SUPABASE_VECTOR_SCHEMA: str = "public"
+    SUPABASE_VECTOR_SOURCE_FILE: str = "app/data/training_data.jsonl"
+    SUPABASE_VECTOR_ON_CONFLICT: str = "chunk_text"
+    SUPABASE_VECTOR_BATCH_SIZE: int = 64
+    SUPABASE_VECTOR_SYNC_ON_STARTUP: bool = True
+
 
     MAIL_PROVIDER: str = "resend"  # "sendgrid" | "brevo_smtp" | "resend"
     EMAIL_FROM: str

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from sqlalchemy import or_
 from app.core.security import verify_password, get_password_hash
 from app.models.user.user_model import User
 from app.db.session import async_engine, SessionLocal
+from app.services.supabase_vector_sync import ensure_supabase_vector_sync
 
 # Imports pour SQLAdmin
 from sqladmin.authentication import AuthenticationBackend
@@ -242,6 +243,8 @@ async def startup():
             logger.info("✅ Administrateur par défaut créé.")
         else:
             logger.info("Administrateur par défaut déjà présent.")
+
+    await ensure_supabase_vector_sync()
 
 # --- Route Racine ---
 @app.get("/")

--- a/app/services/supabase_vector_sync.py
+++ b/app/services/supabase_vector_sync.py
@@ -1,0 +1,209 @@
+"""Utility helpers to synchronise JSONL training data with Supabase vectors.
+
+This module is executed during the FastAPI startup sequence.  It loads a
+JSONL dataset, generates embeddings for each entry and upserts the records into
+the configured Supabase table that uses the ``vector`` extension.  The module
+is intentionally resilient so that missing environment variables or network
+failures do not crash the application startup but instead emit actionable
+logs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, Sequence
+
+import requests
+
+from app.core.config import settings
+from app.core.embeddings import EMBEDDING_DIMENSION, get_text_embedding
+
+
+logger = logging.getLogger(__name__)
+
+
+def _iter_jsonl(path: Path) -> Iterator[dict[str, Any]]:
+    """Yield JSON objects from *path* line by line.
+
+    Invalid lines are skipped with a warning instead of raising an exception so
+    a single malformed example does not break the ingestion.
+    """
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                text = raw_line.strip()
+                if not text:
+                    continue
+
+                try:
+                    yield json.loads(text)
+                except json.JSONDecodeError as exc:  # pragma: no cover - log only
+                    logger.warning(
+                        "JSONL line %s ignored (%s): %s",
+                        line_number,
+                        exc.msg,
+                        text[:120],
+                    )
+    except FileNotFoundError:
+        logger.error("Fichier JSONL introuvable: %s", path)
+    except OSError as exc:
+        logger.error("Impossible de lire le fichier JSONL '%s': %s", path, exc)
+
+
+def _batched(iterable: Iterable[dict[str, Any]], size: int) -> Iterator[list[dict[str, Any]]]:
+    batch: list[dict[str, Any]] = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+
+    if batch:
+        yield batch
+
+
+def _build_payload(records: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Transform raw JSONL rows into Supabase payload dictionaries."""
+
+    payload: list[dict[str, Any]] = []
+
+    for record in records:
+        text = (record.get("text") or record.get("chunk_text") or "").strip()
+        if not text:
+            logger.debug("Entrée ignorée (texte manquant): %s", record)
+            continue
+
+        embedding = get_text_embedding(text)
+        if len(embedding) != EMBEDDING_DIMENSION:
+            logger.warning(
+                "Dimension d'embedding inattendue pour '%s' (attendu=%s, obtenu=%s)",
+                text[:80],
+                EMBEDDING_DIMENSION,
+                len(embedding),
+            )
+            continue
+
+        metadata: Dict[str, Any] = {
+            key: value
+            for key, value in record.items()
+            if key not in {"text", "chunk_text", "domain", "area", "skill", "main_skill"}
+        }
+
+        payload.append(
+            {
+                "chunk_text": text,
+                "embedding": embedding,
+                "domain": record.get("domain"),
+                "area": record.get("area"),
+                "skill": record.get("skill") or record.get("main_skill"),
+                "metadata_": metadata or None,
+            }
+        )
+
+    return payload
+
+
+def _supabase_headers(schema: str | None) -> dict[str, str] | None:
+    key = settings.SUPABASE_SERVICE_ROLE_KEY
+    if not key:
+        return None
+
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "resolution=merge-duplicates",
+    }
+
+    profile = (schema or "public").strip()
+    if profile and profile != "public":
+        headers["Content-Profile"] = profile
+        headers["Accept-Profile"] = profile
+
+    return headers
+
+
+def _supabase_table_url() -> tuple[str, str] | tuple[None, None]:
+    base_url = settings.SUPABASE_URL
+    if not base_url:
+        return None, None
+
+    table = settings.SUPABASE_VECTOR_TABLE.strip()
+    schema = settings.SUPABASE_VECTOR_SCHEMA.strip()
+    if not table:
+        logger.error("Nom de table Supabase invalide.")
+        return None, None
+
+    normalized = str(base_url).rstrip("/")
+    return f"{normalized}/rest/v1/{table}", schema
+
+
+def seed_supabase_vector_store() -> None:
+    """Load embeddings from the JSONL source file and upsert them to Supabase."""
+
+    url, schema = _supabase_table_url()
+    headers = _supabase_headers(schema)
+    if headers is None:
+        logger.info("Clé de service Supabase manquante : synchronisation vectorielle ignorée.")
+        return
+
+    if url is None:
+        logger.info("URL Supabase invalide : synchronisation vectorielle ignorée.")
+        return
+
+    source_path = Path(settings.SUPABASE_VECTOR_SOURCE_FILE)
+    if not source_path.is_file():
+        logger.warning("Fichier de données vectorielles introuvable : %s", source_path)
+        return
+
+    logger.info("Synchronisation Supabase Vector depuis %s", source_path)
+
+    params = {}
+    conflict_column = settings.SUPABASE_VECTOR_ON_CONFLICT.strip()
+    if conflict_column:
+        params["on_conflict"] = conflict_column
+
+    batch_size = max(1, int(settings.SUPABASE_VECTOR_BATCH_SIZE or 1))
+
+    for batch in _batched(_iter_jsonl(source_path), batch_size):
+        payload = _build_payload(batch)
+        if not payload:
+            continue
+
+        try:
+            response = requests.post(url, json=payload, headers=headers, params=params, timeout=30)
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            logger.error("Erreur de connexion à Supabase: %s", exc)
+            return
+
+        if response.status_code >= 400:
+            logger.error(
+                "Échec de l'upsert Supabase (%s): %s",
+                response.status_code,
+                response.text,
+            )
+            return
+
+    logger.info("Synchronisation Supabase Vector terminée.")
+
+
+async def ensure_supabase_vector_sync() -> None:
+    """Trigger the Supabase vector seeding asynchronously during startup."""
+
+    if not settings.SUPABASE_VECTOR_SYNC_ON_STARTUP:
+        logger.info("Synchronisation Supabase désactivée par configuration.")
+        return
+
+    # ``requests`` is blocking, run the seeding in a worker thread to avoid
+    # blocking the FastAPI event loop on startup.
+    try:
+        import asyncio
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, seed_supabase_vector_store)
+    except RuntimeError:
+        # Pas de boucle d'événement (context synchrone), exécute directement.
+        seed_supabase_vector_store()


### PR DESCRIPTION
## Summary
- add configuration knobs for Supabase vector synchronisation
- create a service that loads the JSONL training data, generates embeddings, and upserts them to Supabase
- trigger the Supabase vector sync during FastAPI startup

## Testing
- pytest *(fails: pyenv reports Python 3.11.9 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d671bca0a883278d38e3801ef77bd9