### PR TITLE
Allow configuring DB classifier similarity threshold

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -39,6 +39,9 @@ class Settings(BaseSettings):
     SUPABASE_VECTOR_BATCH_SIZE: int = 64
     SUPABASE_VECTOR_SYNC_ON_STARTUP: bool = True
 
+    # Classification configuration
+    DB_CLASSIFIER_DEFAULT_THRESHOLD: float = 0.2
+
 
     MAIL_PROVIDER: str = "resend"  # "sendgrid" | "brevo_smtp" | "resend"
     EMAIL_FROM: str


### PR DESCRIPTION
## Summary
- allow the database-backed classifier to fall back to a configurable default threshold
- expose the threshold as an environment setting so deployments can tune their sensitivity
- extend the classifier tests to cover the new default threshold behaviour

## Testing
- `pytest tests/test_classification_service.py` *(fails: pyenv reports Python 3.11.9 is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b2a444b48327bec43f54fabda1a8