### PR TITLE
Allow classifier seeding without embeddings

### DIFF
--- a/app/models/analytics/vector_store_model.py
+++ b/app/models/analytics/vector_store_model.py
@@ -18,7 +18,12 @@ class VectorStore(Base):
     chunk_text: Mapped[str] = mapped_column(Text, nullable=False)
     
     # L'embedding de ce texte stocké en JSON pour éviter la dépendance pgvector.
-    embedding: Mapped[list[float]] = mapped_column(JSONB, nullable=False)
+    #
+    # Certaines phases de seed (comme le classifieur texte brut) peuvent décider
+    # de ne pas calculer d'embeddings.  Dans ce cas, on autorise la valeur NULL
+    # et les services en amont appliquent un fallback basé sur des similarités
+    # textuelles.
+    embedding: Mapped[list[float] | None] = mapped_column(JSONB, nullable=True)
 
     # --- NOUVELLES COLONNES POUR LA TAXONOMIE ---
     # Ces colonnes stockent la catégorie associée à ce vecteur


### PR DESCRIPTION
## Summary
- allow vector store entries to omit embeddings so text-only training data can be imported
- add a text-similarity fallback in the database classifier when embeddings are missing
- extend the classifier seeding script with a --skip-embeddings option to keep training data untouched

## Testing
- pytest *(fails: pyenv missing Python 3.11.9)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b92794fc832783078573cb266dcb