### PR TITLE
Add placeholder learning endpoints to avoid 404 responses

### DIFF
--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -19,6 +19,9 @@ from .endpoints import (
     conversation_ws,
     feature_vote_router,
     chat_router,
+    learning_router,
+    journal_router,
+    srs_router,
 )
 
 api_router = APIRouter()
@@ -26,6 +29,9 @@ api_router = APIRouter()
 api_router.include_router(user_router.router, prefix="/users", tags=["Users"])
 api_router.include_router(progress_router.router, prefix="/progress", tags=["Progress"])
 api_router.include_router(toolbox_router.router, prefix="/toolbox", tags=["Toolbox"])
+api_router.include_router(journal_router.router, prefix="/journal", tags=["Journal"])
+api_router.include_router(learning_router.router, prefix="/learning", tags=["Learning"])
+api_router.include_router(srs_router.router, prefix="/srs", tags=["Learning"])
 api_router.include_router(feedback_router.router, prefix="/feedback", tags=["Feedback"])
 api_router.include_router(nlp_router.router, prefix="/nlp", tags=["Nlp"])
 api_router.include_router(capsule_router.router, prefix="/capsules", tags=["Capsule"])

--- a/app/api/v2/endpoints/journal_router.py
+++ b/app/api/v2/endpoints/journal_router.py
@@ -1,0 +1,36 @@
+"""Journal endpoints returning placeholder data.
+
+The frontend expects these routes to exist even though the
+persistence layer is not yet implemented.
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.v2.dependencies import get_current_user, get_db
+from app.models.user.user_model import User
+from app.api.v2.endpoints.learning_router import _build_empty_journal_response
+
+router = APIRouter()
+
+
+@router.get("/", summary="Résumé du journal")
+def list_journal_entries(
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
+) -> dict:
+    """Return an empty set of journal entries with pagination metadata."""
+
+    return _build_empty_journal_response(limit)
+
+
+@router.get("/entries", summary="Entrées détaillées du journal")
+def list_journal_entries_explicit(
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
+) -> dict:
+    """Alias of :func:`list_journal_entries` for frontend compatibility."""
+
+    return _build_empty_journal_response(limit)

--- a/app/api/v2/endpoints/learning_router.py
+++ b/app/api/v2/endpoints/learning_router.py
@@ -1,0 +1,63 @@
+"""Learning-related API endpoints.
+
+These routes currently expose placeholder data so that the
+frontend can safely call the spaced-repetition (SRS) and
+learning journal features without receiving 404 errors.
+Once the dedicated services are implemented the handlers can
+be extended to return real analytics.
+"""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.v2.dependencies import get_current_user, get_db
+from app.models.user.user_model import User
+
+router = APIRouter()
+
+
+def _build_empty_journal_response(limit: int) -> dict:
+    """Return a consistent empty payload for journal endpoints."""
+
+    return {
+        "entries": [],
+        "pagination": {
+            "limit": limit,
+            "returned": 0,
+            "has_more": False,
+        },
+    }
+
+
+def _build_empty_srs_summary(user: User) -> dict:
+    """Return a placeholder SRS summary for the authenticated user."""
+
+    return {
+        "user_id": user.id,
+        "due_today": 0,
+        "overdue": 0,
+        "new_available": 0,
+        "streak": 0,
+        "last_reviewed_at": None,
+    }
+
+
+@router.get("/srs/summary", summary="Résumé de répétition espacée")
+def get_srs_summary(
+    db: Session = Depends(get_db),  # noqa: ARG001 - Reserved for future use
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Return a default spaced-repetition summary for the user."""
+
+    return _build_empty_srs_summary(current_user)
+
+
+@router.get("/journal/entries", summary="Entrées du journal d'apprentissage")
+def list_learning_journal_entries(
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),  # noqa: ARG001 - Reserved for future use
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
+) -> dict:
+    """Return an empty list of learning journal entries for now."""
+
+    return _build_empty_journal_response(limit)

--- a/app/api/v2/endpoints/srs_router.py
+++ b/app/api/v2/endpoints/srs_router.py
@@ -1,0 +1,20 @@
+"""Standalone SRS endpoints (outside of the /learning namespace)."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.v2.dependencies import get_current_user, get_db
+from app.models.user.user_model import User
+from app.api.v2.endpoints.learning_router import _build_empty_srs_summary
+
+router = APIRouter()
+
+
+@router.get("/summary", summary="Résumé global de répétition espacée")
+def get_root_srs_summary(
+    db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for future queries
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Expose the same empty payload as the learning namespace."""
+
+    return _build_empty_srs_summary(current_user)

--- a/app/api/v2/endpoints/toolbox_router.py
+++ b/app/api/v2/endpoints/toolbox_router.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from typing import List, Dict, Any
 
 from app.models.toolbox.molecule_note_model import MoleculeNote
+from app.api.v2.endpoints.learning_router import _build_empty_journal_response
 
 router = APIRouter()
 
@@ -135,3 +136,25 @@ def delete_note(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Note introuvable")
 
     toolbox_notes_crud.delete_note(db, note)
+
+
+@router.get("/journal", summary="Journal de progression (toolbox)")
+def get_toolbox_journal(
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),  # noqa: ARG001 - réservé pour un usage futur
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - garde d'authentification
+) -> dict:
+    """Placeholder endpoint so the frontend can fetch toolbox journal data."""
+
+    return _build_empty_journal_response(limit)
+
+
+@router.get("/journal/entries", summary="Entrées du journal (toolbox)")
+def get_toolbox_journal_entries(
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),  # noqa: ARG001 - réservé pour un usage futur
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - garde d'authentification
+) -> dict:
+    """Alias with the same placeholder payload as :func:`get_toolbox_journal`."""
+
+    return _build_empty_journal_response(limit)


### PR DESCRIPTION
## Summary
- add a learning router with placeholder SRS and journal endpoints so the frontend no longer receives 404 errors
- expose journal endpoints in the toolbox router and a standalone SRS router to cover the fallback URLs the client calls
- register the new routers in the v2 API so the routes are accessible under /learning, /journal and /srs

## Testing
- python3 -m pytest tests/test_config.py *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f6440e7883279ca4f5480d3b1d33