### PR TITLE
Add smart error journal demo payload for learning endpoints

### DIFF
--- a/app/api/v2/endpoints/journal_router.py
+++ b/app/api/v2/endpoints/journal_router.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.api.v2.dependencies import get_current_user, get_db
 from app.models.user.user_model import User
-from app.api.v2.endpoints.learning_router import _build_empty_journal_response
+from app.api.v2.endpoints.learning_router import _build_error_journal_demo
 
 router = APIRouter()
 
@@ -20,9 +20,9 @@ def list_journal_entries(
     db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
     current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
 ) -> dict:
-    """Return an empty set of journal entries with pagination metadata."""
+    """Return the same demo payload as the learning journal endpoint."""
 
-    return _build_empty_journal_response(limit)
+    return _build_error_journal_demo(limit)
 
 
 @router.get("/entries", summary="Entrées détaillées du journal")
@@ -33,4 +33,4 @@ def list_journal_entries_explicit(
 ) -> dict:
     """Alias of :func:`list_journal_entries` for frontend compatibility."""
 
-    return _build_empty_journal_response(limit)
+    return _build_error_journal_demo(limit)

--- a/app/api/v2/endpoints/learning_router.py
+++ b/app/api/v2/endpoints/learning_router.py
@@ -29,6 +29,87 @@ def _build_empty_journal_response(limit: int) -> dict:
     }
 
 
+def _build_error_journal_demo(limit: int) -> dict:
+    """Return a structured payload describing the smart error journal concept."""
+
+    base_entries = [
+        {
+            "id": "smart-error-journal",
+            "title": "Carnet d’erreurs intelligent",
+            "headline": "Journal auto des fautes avec relance d’exercices similaires.",
+            "description": (
+                "Un journal qui agrège automatiquement les erreurs répétées, "
+                "propose de refaire les exercices correspondants et suit la baisse des erreurs récurrentes."
+            ),
+            "value_proposition": [
+                {
+                    "label": "Journal automatique des fautes",
+                    "details": (
+                        "Chaque faute est historisée avec le concept touché et un raccourci « Refaire des exos similaires »."
+                    ),
+                },
+                {
+                    "label": "Cycles de révision intelligents",
+                    "details": (
+                        "Les atomes ratés et déjà générés sont recyclés tant que l’apprenant n’a pas validé de nouveau test."
+                    ),
+                },
+            ],
+            "automation": {
+                "ai_provider": "openai",
+                "premium_frequency": "daily",
+                "free_frequency": "twice_per_week",
+                "outputs": [
+                    "Exercices similaires ciblant la même compétence",
+                    "Tests de validation supplémentaires sur les erreurs identifiées",
+                    "Suggestions regroupées par concept pour suivre la progression",
+                ],
+            },
+            "premium_layer": {
+                "label": "Suggestions ciblées par type d’erreur",
+                "description": (
+                    "Analyse automatique du type d’erreur (concept, compétence, format) et priorisation des actions à mener."
+                ),
+            },
+            "kpis": [
+                {
+                    "id": "recurring_error_rate",
+                    "label": "Baisse d’erreurs récurrentes",
+                    "metric": "recurring_error_rate_7d",
+                    "target": "Tendance à la baisse semaine après semaine",
+                }
+            ],
+            "experiments": [
+                {
+                    "type": "aggregation_par_concept",
+                    "description": (
+                        "Comparer l’agrégation des erreurs par concept avec une vue brute pour valider la pertinence du regroupement."
+                    ),
+                }
+            ],
+            "next_steps": [
+                {
+                    "label": "Refaire des exos similaires",
+                    "action": "launch_retry_session",
+                }
+            ],
+        }
+    ]
+
+    entries = base_entries[:limit]
+    total = len(base_entries)
+
+    return {
+        "entries": entries,
+        "pagination": {
+            "limit": limit,
+            "returned": len(entries),
+            "has_more": total > limit,
+            "total": total,
+        },
+    }
+
+
 def _build_empty_srs_summary(user: User) -> dict:
     """Return a placeholder SRS summary for the authenticated user."""
 
@@ -58,6 +139,6 @@ def list_learning_journal_entries(
     db: Session = Depends(get_db),  # noqa: ARG001 - Reserved for future use
     current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
 ) -> dict:
-    """Return an empty list of learning journal entries for now."""
+    """Return a demo payload describing the smart error journal feature."""
 
-    return _build_empty_journal_response(limit)
+    return _build_error_journal_demo(limit)


### PR DESCRIPTION
## Summary
- add a demo payload describing the smart error journal concept so the frontend can render the feature blueprint
- wire the learning journal and journal endpoints to return the structured payload instead of empty data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f94e04bc8327afd5fdcc956dafc8