### PR TITLE
Add missing learning plan column to Capsule model

### DIFF
--- a/app/models/capsule/capsule_model.py
+++ b/app/models/capsule/capsule_model.py
@@ -32,7 +32,10 @@ class Capsule(Base):
     domain: Mapped[str] = mapped_column(String(100), index=True, nullable=False)
     area: Mapped[str] = mapped_column(String(100), index=True, nullable=False)
     main_skill: Mapped[str] = mapped_column(String(100), index=True, nullable=False)
-    
+    learning_plan_json: Mapped[Optional[Dict[str, Any]]] = mapped_column(
+        JSON, nullable=True
+    )
+
     # Correction: le nom de la colonne est 'creator_id'
     creator_id: Mapped[int] = mapped_column(Integer, ForeignKey("users.id"))
     


### PR DESCRIPTION
## Summary
- add the `learning_plan_json` column to the Capsule SQLAlchemy model so services accessing the attribute do not fail when building atom content

## Testing
- pytest tests/test_capsule_pdf_creation.py::test_capsule_learning_plan_present *(fails: pyenv reports python 3.11.9 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fcf2d5a48327a3892262988d591b