### PR TITLE
Fix CapsuleAdmin column configuration conflict

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -684,7 +684,6 @@ class CapsuleAdmin(ModelView, model=Capsule):
     }
     can_export = True
     if _CAPSULE_PLAN_ATTR is not None:
-        column_exclude_list = [_CAPSULE_PLAN_ATTR]
         column_formatters_detail = {
             _CAPSULE_PLAN_ATTR: lambda m, _: _json_full(getattr(m, "learning_plan_json", None)),
         }


### PR DESCRIPTION
## Summary
- remove the redundant `column_exclude_list` from `CapsuleAdmin` to avoid conflicting SQLAdmin options while keeping custom detail formatting intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6fe1016788327bb8aee64baf42d46