### PR TITLE
Ensure capsule learning plan column exists

### DIFF
--- a/tests/test_startup_schema_adjustments.py
+++ b/tests/test_startup_schema_adjustments.py
@@ -1,0 +1,39 @@
+"""Tests for lightweight startup schema adjustments."""
+
+from sqlalchemy import create_engine, inspect, text
+
+from app.main import _ensure_capsule_learning_plan_column
+
+
+def test_ensure_capsule_learning_plan_column_adds_missing_column():
+    engine = create_engine("sqlite:///:memory:", future=True)
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE capsules (
+                    id INTEGER PRIMARY KEY,
+                    title VARCHAR(255) NOT NULL,
+                    domain VARCHAR(100) NOT NULL,
+                    area VARCHAR(100) NOT NULL,
+                    main_skill VARCHAR(100) NOT NULL,
+                    creator_id INTEGER,
+                    is_public BOOLEAN NOT NULL DEFAULT 1,
+                    generation_status VARCHAR(50) NOT NULL
+                )
+                """
+            )
+        )
+
+        # Initial call should add the missing column without raising.
+        _ensure_capsule_learning_plan_column(connection)
+
+        inspector = inspect(connection)
+        column_names = {column["name"] for column in inspector.get_columns("capsules")}
+        assert "learning_plan_json" in column_names
+
+        # Calling the helper again should be a no-op.
+        _ensure_capsule_learning_plan_column(connection)
+
+    engine.dispose()


### PR DESCRIPTION
## Summary
- ensure the capsules table gets the learning_plan_json column during app startup
- log the on-the-fly schema adjustment and make it idempotent across dialects
- add a regression test covering the helper that patches pre-existing databases

## Testing
- pytest tests/test_startup_schema_adjustments.py *(fails: pyenv missing Python 3.11.9 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ff73e2dc83278b53e8eed3e10fb3