### PR TITLE
Allow general toolbox notes without molecule association

### DIFF
--- a/app/models/toolbox/molecule_note_model.py
+++ b/app/models/toolbox/molecule_note_model.py
@@ -15,7 +15,11 @@ class MoleculeNote(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
-    molecule_id: Mapped[int] = mapped_column(ForeignKey("molecules.id", ondelete="CASCADE"), index=True)
+    molecule_id: Mapped[int | None] = mapped_column(
+        ForeignKey("molecules.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/app/schemas/toolbox/note_schema.py
+++ b/app/schemas/toolbox/note_schema.py
@@ -12,7 +12,7 @@ class MoleculeNoteBase(BaseModel):
 
 
 class MoleculeNoteCreate(MoleculeNoteBase):
-    molecule_id: int = Field(..., gt=0)
+    molecule_id: int | None = Field(None, gt=0)
 
 
 class MoleculeNoteUpdate(BaseModel):
@@ -24,7 +24,7 @@ class MoleculeNoteOut(BaseModel):
     id: int
     title: str
     content: str
-    molecule_id: int
+    molecule_id: int | None
     molecule_title: Optional[str]
     capsule_id: Optional[int]
     capsule_title: Optional[str]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ from app.models.toolbox.coach_conversation_model import (
     CoachConversationMessage,
     CoachConversationThread,
 )
+from app.models.toolbox.molecule_note_model import MoleculeNote
 from app.models.vote.feature_vote_model import FeaturePoll, FeaturePollOption, FeaturePollVote
 from app.models.email.email_token import EmailToken
 
@@ -78,6 +79,7 @@ TABLES = [
     CoachEnergyWallet.__table__,
     CoachConversationThread.__table__,
     CoachConversationMessage.__table__,
+    MoleculeNote.__table__,
     EmailToken.__table__,
     Notification.__table__,
     Badge.__table__,

--- a/tests/test_toolbox_notes.py
+++ b/tests/test_toolbox_notes.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from app.crud import toolbox_notes_crud
+from tests.utils import create_user, create_capsule_graph
+
+
+@pytest.fixture()
+def user(db_session):
+    return create_user(db_session)
+
+
+def test_create_general_note(db_session, user):
+    note = toolbox_notes_crud.create_note(
+        db_session,
+        user,
+        molecule_id=None,
+        title="Note générale",
+        content="Contenu libre",
+    )
+
+    assert note.id is not None
+    assert note.molecule_id is None
+    assert note.title == "Note générale"
+    assert note.content == "Contenu libre"
+
+
+def test_list_notes_filters_by_molecule(db_session, user):
+    _, molecule, *_ = create_capsule_graph(db_session, user_id=user.id)
+
+    general_note = toolbox_notes_crud.create_note(
+        db_session,
+        user,
+        molecule_id=None,
+        title="Note générale",
+        content="Notes pour tout",
+    )
+    molecule_note = toolbox_notes_crud.create_note(
+        db_session,
+        user,
+        molecule_id=molecule.id,
+        title="Note ciblée",
+        content="Notes pour la molécule",
+    )
+
+    all_notes = toolbox_notes_crud.list_notes(db_session, user)
+    assert {note.id for note in all_notes} == {general_note.id, molecule_note.id}
+
+    molecule_notes = toolbox_notes_crud.list_notes(db_session, user, molecule_id=molecule.id)
+    assert [note.id for note in molecule_notes] == [molecule_note.id]
+
+
+def test_create_note_invalid_molecule(db_session, user):
+    with pytest.raises(ValueError):
+        toolbox_notes_crud.create_note(
+            db_session,
+            user,
+            molecule_id=999,
+            title="Note",
+            content="",
+        )


### PR DESCRIPTION
## Summary
- allow toolbox notes to be created without linking them to a molecule
- update CRUD logic, schemas, and test fixtures to support optional molecule references
- add unit tests covering general note creation and filtering behaviour

## Testing
- PYENV_VERSION=3.11.12 python -m pytest tests/test_toolbox_notes.py

------
https://chatgpt.com/codex/tasks/task_e_68d6e3b772548327957a0bd8e82b4802