### PR TITLE
Add compatibility endpoints for toolbox journal and coach conversation

### DIFF
--- a/app/api/v2/endpoints/journal_router.py
+++ b/app/api/v2/endpoints/journal_router.py
@@ -4,33 +4,72 @@ The frontend expects these routes to exist even though the
 persistence layer is not yet implemented.
 """
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Body, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.api.v2.dependencies import get_current_user, get_db
 from app.models.user.user_model import User
 from app.api.v2.endpoints.learning_router import _build_error_journal_demo
+from pydantic import BaseModel, ConfigDict, Field
 
 router = APIRouter()
 
 
+class JournalRequest(BaseModel):
+    """Payload accepted by journal endpoints."""
+
+    model_config = ConfigDict(extra="allow")
+
+    limit: int | None = Field(default=None, ge=1, le=50)
+
+
+def _resolve_limit(limit: int | None, payload: JournalRequest | None) -> int:
+    if payload and payload.limit is not None:
+        return payload.limit
+    if limit is not None:
+        return limit
+    return 10
+
+
 @router.get("/", summary="Résumé du journal")
 def list_journal_entries(
-    limit: int = Query(10, ge=1, le=50),
+    limit: int | None = Query(default=10, ge=1, le=50),
     db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
     current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
 ) -> dict:
     """Return the same demo payload as the learning journal endpoint."""
 
-    return _build_error_journal_demo(limit)
+    return _build_error_journal_demo(_resolve_limit(limit, None))
+
+
+@router.post("/", summary="Résumé du journal")
+def post_journal_entries(
+    payload: JournalRequest | None = Body(default=None),
+    db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
+) -> dict:
+    """POST alias returning the same payload as :func:`list_journal_entries`."""
+
+    return _build_error_journal_demo(_resolve_limit(None, payload))
 
 
 @router.get("/entries", summary="Entrées détaillées du journal")
 def list_journal_entries_explicit(
-    limit: int = Query(10, ge=1, le=50),
+    limit: int | None = Query(default=10, ge=1, le=50),
     db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
     current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
 ) -> dict:
     """Alias of :func:`list_journal_entries` for frontend compatibility."""
 
-    return _build_error_journal_demo(limit)
+    return _build_error_journal_demo(_resolve_limit(limit, None))
+
+
+@router.post("/entries", summary="Entrées détaillées du journal")
+def post_journal_entries_explicit(
+    payload: JournalRequest | None = Body(default=None),
+    db: Session = Depends(get_db),  # noqa: ARG001 - Placeholder for later use
+    current_user: User = Depends(get_current_user),  # noqa: ARG001 - Authentication guard
+) -> dict:
+    """POST alias mirroring :func:`list_journal_entries_explicit`."""
+
+    return _build_error_journal_demo(_resolve_limit(None, payload))


### PR DESCRIPTION
## Summary
- add POST variants for the v2 journal endpoints so POST requests return placeholder data
- expose legacy toolbox coach conversation aliases that return the latest thread or the full list
- refactor toolbox coach listing helpers to reuse statistics computation

## Testing
- pytest tests/test_coach_conversations.py *(fails: pyenv reports required Python 3.11.9 is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d700c294048327a311a667233a3ae9