### PR TITLE
Fix Vercel session reuse and loosen CORS headers

### DIFF
--- a/app/api/v2/dependencies.py
+++ b/app/api/v2/dependencies.py
@@ -2,7 +2,10 @@ import logging
 import re
 from urllib.parse import unquote
 
+from typing import Generator, Optional, Union
+
 from fastapi import Depends, HTTPException, Request, WebSocket, status
+from starlette.datastructures import State
 from sqlalchemy.orm import Session
 from jose import JWTError, ExpiredSignatureError, jwt
 
@@ -13,12 +16,83 @@ from app.models.user.user_model import User
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
-def get_db():
-    db = SessionLocal()
+ScopeType = Union[Request, WebSocket]
+
+
+def _get_state_container(scope: ScopeType | None) -> Optional[State]:
+    """Return the mutable state object associated with the request/websocket."""
+
+    if scope is None:
+        return None
+
+    state = getattr(scope, "state", None)
+    if state is None:
+        state = State()
+        setattr(scope, "state", state)
+    return state
+
+
+def _resolve_scope(
+    request: Request = None,  # type: ignore[assignment]
+    websocket: WebSocket = None,  # type: ignore[assignment]
+) -> ScopeType | None:
+    """Return the current Request or WebSocket when used as a dependency."""
+
+    return request or websocket
+
+
+def get_db(
+    scope: ScopeType | None = Depends(_resolve_scope),
+) -> Generator[Session, None, None]:
+    """Provide a scoped SQLAlchemy session shared within a single request.
+
+    Vercel executes each HTTP invocation in a short-lived worker. When our
+    dependencies requested a session multiple times during a request
+    (``Depends(get_db)`` for the route handler *and* within
+    ``get_current_user``) we ended up creating two independent sessions.  The
+    authentication dependency closed its session immediately after returning the
+    ``User`` instance, leaving the object detached and triggering 500 errors as
+    soon as lazy relationships (enrolments, progress, notification counts…)
+    were accessed in the actual route handler.
+
+    We cache the session on ``request.state`` (or ``websocket.state``) and keep a
+    simple reference counter so the session remains open until the last
+    dependency exits. This mirrors the behaviour of scoped sessions in more
+    traditional ASGI deployments while remaining compatible with background
+    tasks that call ``get_db`` without a request context.
+    """
+
+    if scope is None:
+        db = SessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+        return
+
+    state = _get_state_container(scope)
+    db = getattr(state, "_db_session", None)
+    if db is None:
+        db = SessionLocal()
+        setattr(state, "_db_session", db)
+        setattr(state, "_db_refcount", 0)
+
+    refcount = getattr(state, "_db_refcount", 0) + 1
+    setattr(state, "_db_refcount", refcount)
+
     try:
         yield db
     finally:
-        db.close()
+        refcount = getattr(state, "_db_refcount", 1) - 1
+        if refcount <= 0:
+            try:
+                db.close()
+            finally:
+                for attr in ("_db_session", "_db_refcount"):
+                    if hasattr(state, attr):
+                        delattr(state, attr)
+        else:
+            setattr(state, "_db_refcount", refcount)
 
 def _normalize_token_value(raw_token: str | None) -> str | None:
     """Return a clean JWT string extracted from various transport formats.

--- a/app/main.py
+++ b/app/main.py
@@ -145,13 +145,11 @@ _HTMX_HEADERS = {
     "HX-History-Restore-Request",
 }
 
-cors_headers = {"Authorization", "Content-Type", "X-App-Lang"} | _HTMX_HEADERS
-
 cors_kwargs: dict[str, object] = {
     "allow_origins": cors_origins,
     "allow_credentials": True,
     "allow_methods": ["*"],
-    "allow_headers": sorted(cors_headers),
+    "allow_headers": ["*"],
 }
 
 if cors_regex is not None:


### PR DESCRIPTION
## Summary
- cache the SQLAlchemy session on the request/websocket state so authentication and route handlers share the same connection and avoid detached user errors on Vercel
- relax CORS configuration to allow any request headers, preventing preflight 400 responses from custom frontend headers

## Testing
- pytest tests/test_progress_service_record.py

------
https://chatgpt.com/codex/tasks/task_e_68d7bb82aef083279ccdcb37848bd484