### PR TITLE
Add local SQLite fallback for database startup

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,43 @@
+import sys
+from importlib import import_module, reload
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_session_module():
+    yield
+    sys.modules.pop("app.db.session", None)
+
+
+def _reload_session_module() -> ModuleType:
+    # ``configure_database`` runs at import time, so reloading the module allows
+    # us to exercise the different code paths by tweaking environment variables.
+    session_module = import_module("app.db.session")
+    return reload(session_module)
+
+
+def test_sqlite_sync_parameters(tmp_path, monkeypatch):
+    database_path = tmp_path / "local.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{database_path}")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("DISABLE_SQLITE_FALLBACK", raising=False)
+
+    session_module = _reload_session_module()
+
+    assert session_module.sync_engine.url.drivername == "sqlite"
+    assert session_module.sync_engine.url.database.endswith("local.db")
+
+
+def test_postgres_connection_error_triggers_sqlite_fallback(monkeypatch):
+    # Point the configuration at a non-existent PostgreSQL port so the
+    # connection check fails instantly.  The fallback should switch to the
+    # bundled SQLite database.
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://user:pass@127.0.0.1:65000/app")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("DISABLE_SQLITE_FALLBACK", raising=False)
+
+    session_module = _reload_session_module()
+
+    assert session_module.async_engine.url.drivername == "sqlite+aiosqlite"


### PR DESCRIPTION
## Summary
- add a connection bootstrap helper that verifies the configured database URL and logs the selected engine
- fall back to a bundled SQLite database in development when PostgreSQL refuses the connection
- add tests covering the SQLite driver mapping and fallback behaviour

## Testing
- pytest tests/test_config.py *(fails: pyenv reports that Python 3.11.9/pytest are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7beea15e88327accba2849175e3b5