### PR TITLE
Handle expired access tokens more gracefully

### DIFF
--- a/app/api/v2/endpoints/user_router.py
+++ b/app/api/v2/endpoints/user_router.py
@@ -72,6 +72,9 @@ def login_for_access_token(
 
     # Cookie cross-site pour front/back sur domaines différents (Vercel)
     secure_cookie = settings.ENVIRONMENT == "production"
+    cookie_max_age = security.ACCESS_TOKEN_EXPIRE_MINUTES * 60
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=security.ACCESS_TOKEN_EXPIRE_MINUTES)
+
     response.set_cookie(
         key="access_token",
         value=access_token,   # JWT brut (pas "Bearer ")
@@ -79,6 +82,8 @@ def login_for_access_token(
         samesite="none",      # <- crucial pour cross-site
         secure=secure_cookie, # <- True en prod
         path="/",
+        max_age=cookie_max_age,
+        expires=expires_at,
     )
 
     # Tu renvoies aussi le token dans le body pour le fallback localStorage (dev)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     EMAIL_RESET_TTL_MIN: int = 30
     RESEND_WEBHOOK_SECRET: str | None = None
 
+    # --- Auth configuration ---
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+
     # --- Supabase Vector Store configuration ---
     SUPABASE_URL: AnyHttpUrl | None = None
     SUPABASE_SERVICE_ROLE_KEY: str | None = None

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -13,7 +13,7 @@ from app.core.config import settings
 # --- Configuration de la Sécurité ---
 SECRET_KEY = settings.SECRET_KEY
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.ACCESS_TOKEN_EXPIRE_MINUTES
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- make the JWT expiry configurable via settings and reuse it throughout the authentication layer
- align the login cookie lifetime with the JWT and clear the cookie when the token has expired to force a logout

## Testing
- pytest *(fails: pyenv reports that Python 3.11.9 is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa2e29d088327888ed9caa2b2520f