### PR TITLE
Add uvicorn dependency to restore Fly.io deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "stripe==12.5.1",
     "websocket-client==1.8.0",
     "itsdangerous==2.2.0",
+    "uvicorn==0.32.0",
 ]
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ starlette==0.47.1
 stripe==12.5.1
 websocket-client==1.8.0
 itsdangerous==2.2.0
+uvicorn==0.32.0


### PR DESCRIPTION
## Summary
- add uvicorn to the Python project dependencies so the Fly.io entrypoint command is available

## Testing
- pytest *(fails in container because the requested pyenv Python 3.11.9 version is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcb659f548327a5d28e70646d69c3