### PR TITLE
Force HTTPS redirects in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ USER appuser
 
 EXPOSE 8080
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080", "--proxy-headers", "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
## Summary
- enforce HTTPS redirects and secure session cookies when running in production
- configure uvicorn to trust Fly.io proxy headers so the redirect logic sees the real scheme

## Testing
- pytest *(fails: pyenv reports Python 3.11.9 is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdd1e13448327af74ea388a5f983f