### PR TITLE
Fix ProxyHeadersMiddleware import path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from time import perf_counter
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
-from starlette.middleware.proxyheaders import ProxyHeadersMiddleware
+from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 # Imports de l'application


### PR DESCRIPTION
## Summary
- correct the Starlette ProxyHeaders middleware import to match the package structure

## Testing
- pytest *(fails: pyenv reports Python 3.11.9 is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfef744a488327bb5e8127286dd56b