### PR TITLE
Ensure proxy middleware import works with Starlette 0.47

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,11 @@ from time import perf_counter
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
-from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
+
+try:  # Starlette < 0.47
+    from starlette.middleware.proxy_headers import ProxyHeadersMiddleware
+except ImportError:  # pragma: no cover - Starlette >= 0.47
+    from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 # Imports de l'application


### PR DESCRIPTION
## Summary
- make the proxy headers middleware import compatible with Starlette 0.47 by falling back to Uvicorn's implementation

## Testing
- pytest *(fails: pyenv: version `3.11.9' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dff0fc0f648327a91600cefe37b6cd